### PR TITLE
Responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,10 @@ Calling `(request-factorial 5)` will return a core.async channel for
 you to listen for the result from the "get-factorial"
 queue. `wire-up-service` listens on `factorial-ch` for messages,
 creates a response channel, sends a message to the "get-factorial"
-queue with a correlation ID, listens on a response queue, and finally
-puts the response (edn-decoded, naturally) onto the response channel.
+queue with a correlation ID, listens on a reply-to queue, and finally
+puts the response (edn-decoded, naturally) onto the response
+channel. The reply-to queue must receive a reply within 1000ms,
+otherwise it will close the response channel.
 
 ```clojure
 (let [response-ch (request-factorial 5)]

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ edn and placed on the "updates" queue.
 
 ```clojure
 (ns example
-  (:require [democracyworks.kehaar :as kehaar]
+  (:require [democracyworks.kehaar :as k]
             [langohr.consumers :as lc]))
 
 (defn factorial [n]
@@ -53,7 +53,7 @@ edn and placed on the "updates" queue.
 
 (lc/subscribe a-rabbit-channel
               "get-factorial"
-              (kehaar/simple-responder factorial)
+              (k/simple-responder factorial)
               {:auto-ack true})
 ```
 
@@ -65,15 +65,15 @@ edn and delivered to the reply-to queue with the correlation ID.
 
 ```clojure
 (ns example
-  (:require [democracyworks.kehaar :as kehaar]
+  (:require [democracyworks.kehaar :as k]
             [clojure.core.async :as async]))
 
 (def factorial-ch (async/chan))
 (def request-factorial (kehaar/ch->response-fn factorial-ch))
 
-(kehaar/wire-up-service a-rabbit-channel
-                        "get-factorial"
-                        factorial-ch)
+(k/wire-up-service a-rabbit-channel
+                   "get-factorial"
+                   factorial-ch)
 ```
 
 Calling `(request-factorial 5)` will return a core.async channel for

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A Clojure library designed to pass messages between RabbitMQ and core.async.
 
 (lc/subscribe a-rabbit-channel
               "watership"
-              (k/simple-pass-through messages-from-rabbit)
+              (k/rabbit->async messages-from-rabbit)
               subscribe-options)
 ```
 
@@ -29,13 +29,13 @@ you like.
 ```clojure
 (ns example
   (:require [core.async :as async]
-            [democracyworks.kehaar :as kehaar]))
+            [democracyworks.kehaar :as k]))
 
 (def outgoing-messages (async/chan))
 
-(kehaar/forward outgoing-messages
-                a-rabbit-channel
-                "updates")
+(k/async->rabbit outgoing-messages
+                 a-rabbit-channel
+                 "updates")
 ```
 
 All messages sent to the `outgoing-messages` channel will encoded as

--- a/README.md
+++ b/README.md
@@ -24,6 +24,23 @@ edn-encoded payloads on the "watership" queue will be decoded and
 placed on the `messages-from-rabbit` channel for you to deal with as
 you like.
 
+### Passing messages from core.async to RabbitMQ
+
+```clojure
+(ns example
+  (:require [core.async :as async]
+            [democracyworks.kehaar :as kehaar]))
+
+(def outgoing-messages (async/chan))
+
+(kehaar/forward outgoing-messages
+                a-rabbit-channel
+                "updates")
+```
+
+All messages sent to the `outgoing-messages` channel will encoded as
+edn and placed on the "updates" queue.
+
 ### Applying a function to all messges on a RabbitMQ queue and responding on the reply-to queue with a correlation ID.
 
 ```clojure

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ A Clojure library designed to pass messages between RabbitMQ and core.async.
 
 ## Usage
 
+### Passing messages from RabbitMQ to core.async
+
 ```clojure
 (ns example
   (:require [core.async :as async]
@@ -22,8 +24,52 @@ edn-encoded payloads on the "watership" queue will be decoded and
 placed on the `messages-from-rabbit` channel for you to deal with as
 you like.
 
-Functions for pulling off async channels to publish to RabbitMQ to
-come.
+### Applying a function to all messges on a RabbitMQ queue and responding on the reply-to queue with a correlation ID.
+
+```clojure
+(ns example
+  (:require [democracyworks.kehaar :as kehaar]
+            [langohr.consumers :as kehaar]))
+
+(defn factorial [n]
+  (reduce * 1 (range 1 (inc n))))
+
+(lc/subscribe a-rabbit-channel
+              "get-factorial"
+              (kehaar/simple-responder factorial)
+              {:auto-ack true})
+```
+
+edn-encoded payloads on the "get-factorial" queue will be decoded and
+passed to the `factorial` function and the result will be encoded as
+edn and delivered to the reply-to queue with the correlation ID.
+
+### Using core.async channels to enqueue and receive replies to a RabbitMQ queue
+
+```clojure
+(ns example
+  (:require [democracyworks.kehaar :as kehaar]
+            [clojure.core.async :as async]))
+
+(def factorial-ch (async/chan))
+(def request-factorial (kehaar/ch->response-fn factorial-ch))
+
+(kehaar/wire-up-service a-rabbit-channel
+                        "get-factorial"
+                        factorial-ch)
+```
+
+Calling `(request-factorial 5)` will return a core.async channel for
+you to listen for the result from the "get-factorial"
+queue. `wire-up-service` listens on `factorial-ch` for messages,
+creates a response channel, sends a message to the "get-factorial"
+queue with a correlation ID, listens on a response queue, and finally
+puts the response (edn-decoded, naturally) onto the response channel.
+
+```clojure
+(let [response-ch (request-factorial 5)]
+  (async/<!! response-ch)) ;;=> 120
+```
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ edn and placed on the "updates" queue.
 ```clojure
 (ns example
   (:require [democracyworks.kehaar :as kehaar]
-            [langohr.consumers :as kehaar]))
+            [langohr.consumers :as lc]))
 
 (defn factorial [n]
   (reduce * 1 (range 1 (inc n))))

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ you like.
 All messages sent to the `outgoing-messages` channel will encoded as
 edn and placed on the "updates" queue.
 
-### Applying a function to all messges on a RabbitMQ queue and responding on the reply-to queue with a correlation ID.
+### Applying a function to all messages on a RabbitMQ queue and responding on the reply-to queue with a correlation ID.
 
 ```clojure
 (ns example

--- a/project.clj
+++ b/project.clj
@@ -3,4 +3,5 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.7.0-alpha5"]
-                 [org.clojure/core.async "0.1.346.0-17112a-alpha"]])
+                 [org.clojure/core.async "0.1.346.0-17112a-alpha"]
+                 [com.novemberain/langohr "3.1.0"]])

--- a/src/democracyworks/kehaar.clj
+++ b/src/democracyworks/kehaar.clj
@@ -35,7 +35,7 @@
 
 (defn simple-responder
   "Returns a RabbitMQ message handler function which calls f for each
-  incoming message and replies on the reply-to channel with the
+  incoming message and replies on the reply-to queue with the
   response."
   ([f] (simple-responder f ""))
   ([f exchange]

--- a/src/democracyworks/kehaar.clj
+++ b/src/democracyworks/kehaar.clj
@@ -38,3 +38,14 @@
            response (f message)]
        (lb/publish ch exchange reply-to (pr-str response)
                    {:correlation-id correlation-id})))))
+
+(defn ch->response-fn
+  "Returns a fn that takes a message, creates a core.async channel for
+  the response for that message, and puts [response-channel, message]
+  on the channel given. Returns the response-channel."
+  [channel]
+  (fn [message]
+    (let [response-channel (async/chan)]
+      (async/go
+        (async/>! channel [response-channel message]))
+      response-channel)))

--- a/src/democracyworks/kehaar.clj
+++ b/src/democracyworks/kehaar.clj
@@ -92,5 +92,7 @@
                       :correlation-id correlation-id})
          (async/go
            (async/<! (async/timeout timeout))
+           (when-let [response-channel (@pending-calls correlation-id)]
+             (async/close! response-channel))
            (swap! pending-calls dissoc correlation-id))
          (recur))))))

--- a/src/democracyworks/kehaar.clj
+++ b/src/democracyworks/kehaar.clj
@@ -29,6 +29,17 @@
     (async/pipeline 1 channel (map #(nth % 2)) middleman)
     (pass-through middleman)))
 
+(defn forward
+  "Forward all messages on channel to the RabbitMQ queue."
+  [channel rabbit-channel exchange queue queue-options]
+  (lq/declare rabbit-channel
+              queue
+              queue-options)
+  (async/go-loop []
+    (let [message (async/<! channel)]
+      (lb/publish rabbit-channel exchange queue (pr-str message))
+      (recur))))
+
 (defn simple-responder
   "Returns a RabbitMQ message handler function which calls f for each
   incoming message and replies on the reply-to channel with the

--- a/src/democracyworks/kehaar.clj
+++ b/src/democracyworks/kehaar.clj
@@ -31,14 +31,16 @@
 
 (defn forward
   "Forward all messages on channel to the RabbitMQ queue."
-  [channel rabbit-channel exchange queue queue-options]
-  (lq/declare rabbit-channel
-              queue
-              queue-options)
-  (async/go-loop []
-    (let [message (async/<! channel)]
-      (lb/publish rabbit-channel exchange queue (pr-str message))
-      (recur))))
+  ([channel rabbit-channel queue]
+   (forward channel rabbit-channel "" queue {:exclusive false :auto-delete true}))
+  ([channel rabbit-channel exchange queue queue-options]
+   (lq/declare rabbit-channel
+               queue
+               queue-options)
+   (async/go-loop []
+     (let [message (async/<! channel)]
+       (lb/publish rabbit-channel exchange queue (pr-str message))
+       (recur)))))
 
 (defn simple-responder
   "Returns a RabbitMQ message handler function which calls f for each

--- a/test/democracyworks/kehaar_test.clj
+++ b/test/democracyworks/kehaar_test.clj
@@ -18,22 +18,9 @@
       metadata {:year 2015}
       payload (edn-bytes message)]
 
-  (deftest pass-through-test
+  (deftest rabbit->async-test
     (let [c (async/chan)
-          handler (pass-through c)]
-      (testing "passes through rabbit channel and metadata"
-        (handler rabbit-ch metadata payload)
-        (let [[returned-ch returned-metadata _]  (async/<!! c)]
-          (is (= returned-ch rabbit-ch))
-          (is (= returned-metadata metadata))))
-      (testing "passes through the edn-decoded payload"
-        (handler rabbit-ch metadata payload)
-        (let [[_ _ returned-message] (async/<!! c)]
-          (is (= returned-message message))))))
-
-  (deftest simple-pass-through-test
-    (let [c (async/chan)
-          handler (simple-pass-through c)]
+          handler (rabbit->async c)]
       (testing "only passes through the edn-decoded payload"
         (handler rabbit-ch metadata payload)
         (let [returned-message (async/<!! c)]

--- a/test/democracyworks/kehaar_test.clj
+++ b/test/democracyworks/kehaar_test.clj
@@ -38,3 +38,10 @@
         (handler rabbit-ch metadata payload)
         (let [returned-message (async/<!! c)]
           (is (= returned-message message)))))))
+
+(deftest ch->response-fn-test
+  (let [c (async/chan)
+        response-fn (ch->response-fn c)
+        message {:test true}
+        response-channel (response-fn message)]
+    (is (= [response-channel message] (async/<!! c)))))


### PR DESCRIPTION
New functions:

* `forward`: messages from core.async to RabbitMQ
* `simple-responder`: creates a message handler that applies a function to all messages and returns them on the reply-to queue
* `ch->response-fn`: given a channel, get a function that puts values on that channel and returns a channel to listen for a response on
* `wire-up-service`: use a "response-fn" from `ch->response-fn` to place messages on an outgoing queue, and receive responses on a one-time channel

Naming assistance appreciated.