### PR TITLE
Refactoring

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,4 @@
 language: clojure
+script: lein test :all
+services:
+  - rabbitmq

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -31,6 +31,13 @@ either. **This is a breaking change.** Queues must now already be
 delcared. Additionally, internally, it uses a server-named, exclusive,
 auto-deleted queue.
 
+### kehaar/responder
+
+`kehaar/simple-responder` has been renamed `kehaar/fn->handler-fn` and
+a new function `kehaar/responder` has been made which takes a RabbitMQ
+channel and queue and a function to apply to all messages, replying on
+the reply-to queue with the result. **This is a breaking change.**
+
 ### Tests using RabbitMQ
 
 There are now tests which use RabbitMQ, however they are not run by

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -24,6 +24,11 @@ other.
 `kehaar/rabbit->async-handler-fn` now blocks if the async channel's
 buffer is full, providing the opportunity for some back pressure.
 
+### kehaar/ch->response-fn
+
+`kehaar/ch->response-fn` now returns promises instead of async
+channels for the caller to wait on. **This is a breaking change.**
+
 ### kehaar/wire-up-service
 
 `kehaar/wire-up-service` no longer declares the queue it operates on

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -11,8 +11,18 @@ declared. This allows, for example, the queue to be
 
 ### kehaar/rabbit->async
 
-`kehaar/rabbit->async` now blocks if the async channel's buffer is
-full, providing the opportunity for some back pressure.
+The old `kehaar/rabbit->async` function has been renamed
+`kehaar/rabbit->async-handler-fn`, and `kehaar/rabbit->async` now
+takes the RabbitMQ queue and the async channel, handling the
+subscription for you. **This is a breaking change.**
+
+`rabbit->async` and `async->rabbit` now appropriately mirror the
+other.
+
+### kehaar/rabbit->async-handler-fn
+
+`kehaar/rabbit->async-handler-fn` now blocks if the async channel's
+buffer is full, providing the opportunity for some back pressure.
 
 ### kehaar/wire-up-service
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -27,7 +27,7 @@ buffer is full, providing the opportunity for some back pressure.
 ### kehaar/wire-up-service
 
 `kehaar/wire-up-service` no longer declares the queue it operates on
-either. **This is a breaking cahnge.** Queues must now already be
+either. **This is a breaking change.** Queues must now already be
 delcared. Additionally, internally, it uses a server-named, exclusive,
 auto-deleted queue.
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,3 +8,12 @@
 on. **This is a breaking change.** Queues must now be already
 declared. This allows, for example, the queue to be
 [a server-named, exclusive, auto-deleted queue](http://clojurerabbitmq.info/articles/queues.html#declaring-a-temporary-exclusive-queue).
+
+### Tests using RabbitMQ
+
+There are now tests which use RabbitMQ, however they are not run by
+default with `lein run`. In order to run the RabbitMQ tests, start
+`rabbitmq-server` with its default configuration and run `lein test
+:rabbit-mq`. To run all tests, run `lein test :all`.
+
+Travis CI has been updated to run those tests as well.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,6 +9,11 @@ on. **This is a breaking change.** Queues must now be already
 declared. This allows, for example, the queue to be
 [a server-named, exclusive, auto-deleted queue](http://clojurerabbitmq.info/articles/queues.html#declaring-a-temporary-exclusive-queue).
 
+### kehaar/rabbit->async
+
+`kehaar/rabbit->async` now blocks if the async channel's buffer is
+full, providing the opportunity for some back pressure.
+
 ### kehaar/wire-up-service
 
 `kehaar/wire-up-service` no longer declares the queue it operates on

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,6 +9,13 @@ on. **This is a breaking change.** Queues must now be already
 declared. This allows, for example, the queue to be
 [a server-named, exclusive, auto-deleted queue](http://clojurerabbitmq.info/articles/queues.html#declaring-a-temporary-exclusive-queue).
 
+### kehaar/wire-up-service
+
+`kehaar/wire-up-service` no longer declares the queue it operates on
+either. **This is a breaking cahnge.** Queues must now already be
+delcared. Additionally, internally, it uses a server-named, exclusive,
+auto-deleted queue.
+
 ### Tests using RabbitMQ
 
 There are now tests which use RabbitMQ, however they are not run by

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,0 +1,10 @@
+# Change Log
+
+## Changes between Kehaar 0.1.0 and 0.x
+
+### kehaar/async->rabbit
+
+`kehaar/async->rabbit` no longer declares the queue it operates
+on. **This is a breaking change.** Queues must now be already
+declared. This allows, for example, the queue to be
+[a server-named, exclusive, auto-deleted queue](http://clojurerabbitmq.info/articles/queues.html#declaring-a-temporary-exclusive-queue).

--- a/README.md
+++ b/README.md
@@ -53,10 +53,9 @@ edn and placed on the "updates" queue.
 (defn factorial [n]
   (reduce * 1 (range 1 (inc n))))
 
-(lc/subscribe a-rabbit-channel
-              "get-factorial"
-              (k/simple-responder factorial)
-              {:auto-ack true})
+(responder a-rabbit-channel
+           "get-factorial"
+           factorial)
 ```
 
 edn-encoded payloads on the "get-factorial" queue will be decoded and

--- a/README.md
+++ b/README.md
@@ -13,15 +13,13 @@ Add `[democracyworks/kehaar "0.1.0-SNAPSHOT"]` to your dependencies.
 ```clojure
 (ns example
   (:require [core.async :as async]
-            [kehaar :as k]
-            [langohr.consumers :as lc]))
+            [kehaar :as k]))
 
 (def messages-from-rabbit (async/chan))
 
-(lc/subscribe a-rabbit-channel
-              "watership"
-              (k/rabbit->async messages-from-rabbit)
-              subscribe-options)
+(k/rabbit->async a-rabbit-channel
+                 "watership"
+                 messages-from-rabbit)
 ```
 
 edn-encoded payloads on the "watership" queue will be decoded and

--- a/README.md
+++ b/README.md
@@ -77,18 +77,18 @@ edn and delivered to the reply-to queue with the correlation ID.
                    factorial-ch)
 ```
 
-Calling `(request-factorial 5)` will return a core.async channel for
-you to listen for the result from the "get-factorial"
-queue. `wire-up-service` listens on `factorial-ch` for messages,
-creates a response channel, sends a message to the "get-factorial"
-queue with a correlation ID, listens on a reply-to queue, and finally
-puts the response (edn-decoded, naturally) onto the response
-channel. The reply-to queue must receive a reply within 1000ms,
-otherwise it will close the response channel.
+Calling `(request-factorial 5)` will return a promise for you to wait
+for the result from the "get-factorial" queue. `wire-up-service`
+listens on `factorial-ch` for messages, creates a response promise,
+sends a message to the "get-factorial" queue with a correlation ID,
+listens on a reply-to queue, and finally delivers the response
+(edn-decoded, naturally) to the response promise. The reply-to queue
+must receive a reply within 5 minutes, otherwise it won't deliver the
+promise.
 
 ```clojure
-(let [response-ch (request-factorial 5)]
-  (async/<!! response-ch)) ;;=> 120
+(let [response-promise (request-factorial 5)]
+  @response-promise ;;=> 120
 ```
 
 ## License

--- a/project.clj
+++ b/project.clj
@@ -4,4 +4,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.7.0-alpha5"]
                  [org.clojure/core.async "0.1.346.0-17112a-alpha"]
-                 [com.novemberain/langohr "3.1.0"]])
+                 [com.novemberain/langohr "3.1.0"]]
+  :test-selectors {:default (complement :rabbit-mq)
+                   :rabbit-mq :rabbit-mq
+                   :all (constantly true)})

--- a/src/kehaar.clj
+++ b/src/kehaar.clj
@@ -23,11 +23,8 @@
 (defn async->rabbit
   "Forward all messages on channel to the RabbitMQ queue."
   ([channel rabbit-channel queue]
-   (async->rabbit channel rabbit-channel "" queue {:exclusive false :auto-delete true}))
-  ([channel rabbit-channel exchange queue queue-options]
-   (lq/declare rabbit-channel
-               queue
-               queue-options)
+   (async->rabbit channel rabbit-channel "" queue))
+  ([channel rabbit-channel exchange queue]
    (async/go-loop []
      (let [message (async/<! channel)]
        (lb/publish rabbit-channel exchange queue (pr-str message))

--- a/src/kehaar.clj
+++ b/src/kehaar.clj
@@ -61,14 +61,8 @@
                     queue {:exclusive false :auto-delete true}
                     1000 channel))
   ([rabbit-channel exchange queue queue-options timeout channel]
-   (let [response-queue (str queue "." (java.util.UUID/randomUUID))
+   (let [response-queue (lq/declare-server-named rabbit-channel {:exclusive true :auto-delete true})
          pending-calls (atom {})]
-     (lq/declare rabbit-channel
-                 queue
-                 queue-options)
-     (lq/declare rabbit-channel
-                 response-queue
-                 {:exclusive true :auto-delete true})
      (lc/subscribe rabbit-channel
                    response-queue
                    (fn [ch {:keys [correlation-id]} ^bytes payload]

--- a/src/kehaar.clj
+++ b/src/kehaar.clj
@@ -16,9 +16,8 @@
   edn strings."
   [channel]
   (fn [ch meta ^bytes payload]
-    (async/go
-      (let [message (read-payload payload)]
-        (async/>! channel message)))))
+    (let [message (read-payload payload)]
+      (async/>!! channel message))))
 
 (defn async->rabbit
   "Forward all messages on channel to the RabbitMQ queue."

--- a/test/kehaar/rabbit_mq_test.clj
+++ b/test/kehaar/rabbit_mq_test.clj
@@ -31,7 +31,7 @@
         chan (async/chan)
         response-fn (ch->response-fn chan)]
 
-    (lc/subscribe ch rabbit-queue (simple-responder str))
+    (responder ch rabbit-queue str)
     (wire-up-service ch rabbit-queue chan)
 
     (let [message {:testing "wire-up"}

--- a/test/kehaar/rabbit_mq_test.clj
+++ b/test/kehaar/rabbit_mq_test.clj
@@ -35,8 +35,8 @@
     (wire-up-service ch rabbit-queue chan)
 
     (let [message {:testing "wire-up"}
-          response-chan (response-fn message)
-          response (async/<!! response-chan)]
+          response-promise (response-fn message)
+          response @response-promise]
       (is (= response (str message))))
 
     (rmq/close ch)

--- a/test/kehaar/rabbit_mq_test.clj
+++ b/test/kehaar/rabbit_mq_test.clj
@@ -1,0 +1,24 @@
+(ns kehaar.rabbit-mq-test
+  (:require [clojure.test :refer :all]
+            [kehaar :refer :all]
+            [clojure.core.async :as async]
+            [langohr.core :as rmq]
+            [langohr.channel :as lch]
+            [langohr.queue :as lq]
+            [langohr.basic :as lb]
+            [langohr.consumers :as lc]))
+
+(deftest ^:rabbit-mq async->rabbit-rabbit->async-test
+  (let [conn (rmq/connect)
+        ch (lch/open conn)
+        rabbit-queue (lq/declare-server-named ch {:exclusive true})
+        chan (async/chan)
+        response-chan (async/chan)
+        message {:test (java.util.UUID/randomUUID)}]
+    (async->rabbit chan ch rabbit-queue)
+    (lc/subscribe ch rabbit-queue (rabbit->async response-chan) {:auto-ack true})
+    (async/>!! chan message)
+    (is (= message (async/<!! response-chan)))
+
+    (rmq/close ch)
+    (rmq/close conn)))

--- a/test/kehaar/rabbit_mq_test.clj
+++ b/test/kehaar/rabbit_mq_test.clj
@@ -16,7 +16,7 @@
         response-chan (async/chan)
         message {:test (java.util.UUID/randomUUID)}]
     (async->rabbit chan ch rabbit-queue)
-    (lc/subscribe ch rabbit-queue (rabbit->async response-chan) {:auto-ack true})
+    (rabbit->async ch rabbit-queue response-chan)
     (async/>!! chan message)
     (is (= message (async/<!! response-chan)))
 

--- a/test/kehaar_test.clj
+++ b/test/kehaar_test.clj
@@ -30,5 +30,5 @@
   (let [c (async/chan)
         response-fn (ch->response-fn c)
         message {:test true}
-        response-channel (response-fn message)]
-    (is (= [response-channel message] (async/<!! c)))))
+        response-promise (response-fn message)]
+    (is (= [response-promise message] (async/<!! c)))))

--- a/test/kehaar_test.clj
+++ b/test/kehaar_test.clj
@@ -18,9 +18,9 @@
       metadata {:year 2015}
       payload (edn-bytes message)]
 
-  (deftest rabbit->async-test
-    (let [c (async/chan)
-          handler (rabbit->async c)]
+  (deftest rabbit->async-handler-fn-test
+    (let [c (async/chan 1)
+          handler (rabbit->async-handler-fn c)]
       (testing "only passes through the edn-decoded payload"
         (handler rabbit-ch metadata payload)
         (let [returned-message (async/<!! c)]


### PR DESCRIPTION
The ChangeLog has a pretty detailed explanation of what's happened. Generally:

* None of the functions at this level of abstraction declare Rabbit queues anymore (that *could* happen in future functions that call these).
* Function signatures have been rationalized (`rabbit->async` and `async->rabbit` now look like the other, for example).
* Some light renaming.
* Tests that actually exercise RabbitMQ have been added.

This branch has been released as 0.2.0-SNAPSHOT (though that is not represented in the project.clj).

If merged, the project.clj should be updated to 0.2.0 and a new release to clojars should be pushed out.