### PR TITLE
Stop looping on nil take

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -2,9 +2,9 @@
   :description "Kehaar passes messages to and from RabbitMQ channels"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.7.0-alpha5"]
+  :dependencies [[org.clojure/clojure "1.7.0-beta3"]
                  [org.clojure/core.async "0.1.346.0-17112a-alpha"]
-                 [com.novemberain/langohr "3.1.0"]]
+                 [com.novemberain/langohr "3.2.0"]]
   :test-selectors {:default (complement :rabbit-mq)
                    :rabbit-mq :rabbit-mq
                    :all (constantly true)})

--- a/src/kehaar.clj
+++ b/src/kehaar.clj
@@ -36,9 +36,10 @@
    (async->rabbit channel rabbit-channel "" queue))
   ([channel rabbit-channel exchange queue]
    (async/go-loop []
-     (when-let [message (async/<! channel)]
-       (lb/publish rabbit-channel exchange queue (pr-str message))
-       (recur)))))
+     (let [message (async/<! channel)]
+       (when-not (nil? message)
+         (lb/publish rabbit-channel exchange queue (pr-str message))
+         (recur))))))
 
 (defn fn->handler-fn
   "Returns a RabbitMQ message handler function which calls f for each
@@ -94,16 +95,18 @@
                        (swap! pending-calls dissoc correlation-id)))
                    {:auto-ack true})
      (async/go-loop []
-       (when-let [[response-promise message] (async/<! channel)]
-         (let [correlation-id (str (java.util.UUID/randomUUID))]
-           (swap! pending-calls assoc correlation-id response-promise)
-           (lb/publish rabbit-channel
-                       exchange
-                       queue
-                       (pr-str message)
-                       {:reply-to response-queue
-                        :correlation-id correlation-id})
-           (async/go
-             (async/<! (async/timeout timeout))
-             (swap! pending-calls dissoc correlation-id))
-           (recur)))))))
+       (let [ch-message (async/<! channel)]
+         (when-not (nil? ch-message)
+           (let [[response-promise message] ch-message
+                 correlation-id (str (java.util.UUID/randomUUID))]
+             (swap! pending-calls assoc correlation-id response-promise)
+             (lb/publish rabbit-channel
+                         exchange
+                         queue
+                         (pr-str message)
+                         {:reply-to response-queue
+                          :correlation-id correlation-id})
+             (async/go
+               (async/<! (async/timeout timeout))
+               (swap! pending-calls dissoc correlation-id))
+             (recur))))))))

--- a/src/kehaar.clj
+++ b/src/kehaar.clj
@@ -36,7 +36,7 @@
    (async->rabbit channel rabbit-channel "" queue))
   ([channel rabbit-channel exchange queue]
    (async/go-loop []
-     (let [message (async/<! channel)]
+     (when-let [message (async/<! channel)]
        (lb/publish rabbit-channel exchange queue (pr-str message))
        (recur)))))
 
@@ -94,16 +94,16 @@
                        (swap! pending-calls dissoc correlation-id)))
                    {:auto-ack true})
      (async/go-loop []
-       (let [[response-promise message] (async/<! channel)
-             correlation-id (str (java.util.UUID/randomUUID))]
-         (swap! pending-calls assoc correlation-id response-promise)
-         (lb/publish rabbit-channel
-                     exchange
-                     queue
-                     (pr-str message)
-                     {:reply-to response-queue
-                      :correlation-id correlation-id})
-         (async/go
-           (async/<! (async/timeout timeout))
-           (swap! pending-calls dissoc correlation-id))
-         (recur))))))
+       (when-let [[response-promise message] (async/<! channel)]
+         (let [correlation-id (str (java.util.UUID/randomUUID))]
+           (swap! pending-calls assoc correlation-id response-promise)
+           (lb/publish rabbit-channel
+                       exchange
+                       queue
+                       (pr-str message)
+                       {:reply-to response-queue
+                        :correlation-id correlation-id})
+           (async/go
+             (async/<! (async/timeout timeout))
+             (swap! pending-calls dissoc correlation-id))
+           (recur)))))))


### PR DESCRIPTION
When you take nil from a core.async channel, that means it is closed. So we should stop looping when that happens and not process the nil value.