### PR TITLE
Add logging and ack on take

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,35 @@
 # Change Log
 
+## Changes between Kehaar 0.2.1 and 0.2.2
+
+### Add `kehaar.core` namespace
+
+Since single-level namespaces are not recommended in Clojure, we have
+moved the code that was in `kehaar` to a new `kehaar.core` ns.
+**This is a breaking change.** You will need to update all your
+`(ns ... (:require [kehaar]))` forms in your code to look more like
+this instead: `(ns ... (:require [kehaar.core]))`.
+
+### Ack-on-take in `rabbit->async`
+
+Previously kehaar auto-acked every incoming RabbitMQ message. Now it
+acks only when something successfully consumes the message from the
+core.async channel that it is forwarded to.
+
+### Logging
+
+There are now debug-level log messages when Kehaar consumes a RabbitMQ
+message and when it forwards them on to core.async channels.
+
+There are also warn-level log messages when it tries to take from a
+closed core.async channel.
+
+This adds a dependency on `clojure.tools.logging` 0.3.1.
+
+### Updated dependencies
+
+Use Clojure 1.7.0-RC2
+
 ## Changes between Kehaar 0.2.0 and 0.2.1
 
 ### `nil?` checks when taking values from async channels

--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,8 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.7.0-RC1"]
                  [org.clojure/core.async "0.1.346.0-17112a-alpha"]
-                 [com.novemberain/langohr "3.2.0"]]
+                 [com.novemberain/langohr "3.2.0"]
+                 [org.clojure/tools.logging "0.3.1"]]
   :test-selectors {:default (complement :rabbit-mq)
                    :rabbit-mq :rabbit-mq
                    :all (constantly true)})

--- a/project.clj
+++ b/project.clj
@@ -2,7 +2,7 @@
   :description "Kehaar passes messages to and from RabbitMQ channels"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.7.0-RC1"]
+  :dependencies [[org.clojure/clojure "1.7.0-RC2"]
                  [org.clojure/core.async "0.1.346.0-17112a-alpha"]
                  [com.novemberain/langohr "3.2.0"]
                  [org.clojure/tools.logging "0.3.1"]]

--- a/project.clj
+++ b/project.clj
@@ -2,7 +2,7 @@
   :description "Kehaar passes messages to and from RabbitMQ channels"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.7.0-beta3"]
+  :dependencies [[org.clojure/clojure "1.7.0-RC1"]
                  [org.clojure/core.async "0.1.346.0-17112a-alpha"]
                  [com.novemberain/langohr "3.2.0"]]
   :test-selectors {:default (complement :rabbit-mq)

--- a/src/kehaar/core.clj
+++ b/src/kehaar/core.clj
@@ -43,7 +43,7 @@
    (async/go-loop []
      (let [message (async/<! channel)]
        (if (nil? message)
-         (log/warn "Kehaar: Received nil from core.async channel for" queue)
+         (log/warn "Kehaar: core.async channel for" queue "is closed")
          (do (lb/publish rabbit-channel exchange queue (pr-str message))
              (recur)))))))
 
@@ -103,7 +103,7 @@
      (async/go-loop []
        (let [ch-message (async/<! channel)]
          (if (nil? ch-message)
-           (log/warn "Kehaar: Received nil from core.async channel for" queue)
+           (log/warn "Kehaar: core.async channel for" queue "is closed")
            (let [[response-promise message] ch-message
                  correlation-id (str (java.util.UUID/randomUUID))]
              (swap! pending-calls assoc correlation-id response-promise)

--- a/src/kehaar/core.clj
+++ b/src/kehaar/core.clj
@@ -27,7 +27,7 @@
   "Subscribes to the RabbitMQ queue, taking each payload, decoding as
   edn, and putting the result onto the async channel."
   ([rabbit-channel queue channel]
-   (rabbit->async rabbit-channel queue channel {:auto-ack false}))
+   (rabbit->async rabbit-channel queue channel {}))
   ([rabbit-channel queue channel options]
    (lc/subscribe rabbit-channel
                  queue

--- a/src/kehaar/core.clj
+++ b/src/kehaar/core.clj
@@ -16,12 +16,12 @@
   message payloads to `channel`. Assumes that all payloads are UTF-8
   edn strings. Returned fn returns the message delivery tag."
   [channel]
-  (fn [ch meta ^bytes payload]
+  (fn [ch {:keys delivery-tag} ^bytes payload]
     (let [message (read-payload payload)]
-      (log/info "Kehaar: Consuming message:" (pr-str message))
+      (log/info "Kehaar: Consuming message" (str "(delivery-tag " delivery-tag "): ") (pr-str message))
       (async/>!! channel message)
-      (log/info "Kehaar: Successfully forwarded last message to core.async channel")
-      (:delivery-tag meta))))
+      (log/info "Kehaar: Successfully forwarded message" (str "(delivery-tag " delivery-tag ")") "to core.async channel")
+      delivery-tag)))
 
 (defn rabbit->async
   "Subscribes to the RabbitMQ queue, taking each payload, decoding as

--- a/src/kehaar/core.clj
+++ b/src/kehaar/core.clj
@@ -18,9 +18,9 @@
   [channel]
   (fn [ch {:keys [delivery-tag]} ^bytes payload]
     (let [message (read-payload payload)]
-      (log/info "Kehaar: Consuming message" (str "(delivery-tag " delivery-tag "): ") (pr-str message))
+      (log/debug "Kehaar: Consuming message" (str "(delivery-tag " delivery-tag "): ") (pr-str message))
       (async/>!! channel message)
-      (log/info "Kehaar: Successfully forwarded message" (str "(delivery-tag " delivery-tag ")") "to core.async channel")
+      (log/debug "Kehaar: Successfully forwarded message" (str "(delivery-tag " delivery-tag ")") "to core.async channel")
       delivery-tag)))
 
 (defn rabbit->async

--- a/src/kehaar/core.clj
+++ b/src/kehaar/core.clj
@@ -16,7 +16,7 @@
   message payloads to `channel`. Assumes that all payloads are UTF-8
   edn strings. Returned fn returns the message delivery tag."
   [channel]
-  (fn [ch {:keys delivery-tag} ^bytes payload]
+  (fn [ch {:keys [delivery-tag]} ^bytes payload]
     (let [message (read-payload payload)]
       (log/info "Kehaar: Consuming message" (str "(delivery-tag " delivery-tag "): ") (pr-str message))
       (async/>!! channel message)

--- a/test/kehaar/core_test.clj
+++ b/test/kehaar/core_test.clj
@@ -15,7 +15,7 @@
                :test true
                :moon-landing #inst "1969-07-20"}
       rabbit-ch :rabbit-channel
-      metadata {:year 2015}
+      metadata {:year 2015 :delivery-tag 8675309}
       payload (edn-bytes message)]
 
   (deftest rabbit->async-handler-fn-test
@@ -24,7 +24,11 @@
       (testing "only passes through the edn-decoded payload"
         (handler rabbit-ch metadata payload)
         (let [returned-message (async/<!! c)]
-          (is (= returned-message message)))))))
+          (is (= returned-message message))))
+      (testing "returns the delivery-tag metadata"
+        (is (= (:delivery-tag metadata)
+               (handler rabbit-ch metadata payload)))
+        (async/<!! c)))))
 
 (deftest ch->response-fn-test
   (let [c (async/chan)

--- a/test/kehaar/rabbit_mq_test.clj
+++ b/test/kehaar/rabbit_mq_test.clj
@@ -19,7 +19,7 @@
     (rabbit->async ch rabbit-queue response-chan)
     (async/>!! chan message)
     (is (= message (async/<!! response-chan)))
-
+    (Thread/sleep 500) ; wait for ack before closing channel
     (rmq/close ch)
     (rmq/close conn)))
 


### PR DESCRIPTION
This is an attempt to improve upon and debug the issue I'm seeing in production where, when a kehaar-using component has been running for awhile it will stop consuming incoming messages. They will arrive on the Rabbit queue, and kehaar will get them, but then it auto-acks them, tries to >!! them onto the core.async channel, and then (presumably) blocks forever.

See individual commits for details.