### PR TITLE
Revert to chan in response fns

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -66,6 +66,11 @@ other.
 `kehaar/rabbit->async-handler-fn` now blocks if the async channel's
 buffer is full, providing the opportunity for some back pressure.
 
+### kehaar/ch->response-fn
+
+`kehaar/ch->response-fn` now returns promises instead of async
+channels for the caller to wait on. **This is a breaking change.**
+
 ### kehaar/wire-up-service
 
 `kehaar/wire-up-service` no longer declares the queue it operates on

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -66,11 +66,6 @@ other.
 `kehaar/rabbit->async-handler-fn` now blocks if the async channel's
 buffer is full, providing the opportunity for some back pressure.
 
-### kehaar/ch->response-fn
-
-`kehaar/ch->response-fn` now returns promises instead of async
-channels for the caller to wait on. **This is a breaking change.**
-
 ### kehaar/wire-up-service
 
 `kehaar/wire-up-service` no longer declares the queue it operates on

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## Changes between Kehaar 0.3.0 and HEAD
+
+### kehaar.core/ch->response-fn
+
+In 0.2.0 `ch->response-fn` started returning promises instead of core.async
+channels. That is now reverted back to core.async channels.
+**This is a breaking change.**
+
 ## Changes between Kehaar 0.2.1 and 0.3.0
 
 ### Add `kehaar.core` namespace

--- a/README.md
+++ b/README.md
@@ -77,18 +77,18 @@ edn and delivered to the reply-to queue with the correlation ID.
                    factorial-ch)
 ```
 
-Calling `(request-factorial 5)` will return a promise for you to wait
-for the result from the "get-factorial" queue. `wire-up-service`
-listens on `factorial-ch` for messages, creates a response promise,
-sends a message to the "get-factorial" queue with a correlation ID,
-listens on a reply-to queue, and finally delivers the response
-(edn-decoded, naturally) to the response promise. The reply-to queue
-must receive a reply within 5 minutes, otherwise it won't deliver the
-promise.
+Calling `(request-factorial 5)` will return a core.async channel for
+you to listen for the result from the "get-factorial"
+queue. `wire-up-service` listens on `factorial-ch` for messages,
+creates a response channel, sends a message to the "get-factorial"
+queue with a correlation ID, listens on a reply-to queue, and finally
+puts the response (edn-decoded, naturally) onto the response
+channel. The reply-to queue must receive a reply within 1000ms,
+otherwise it will close the response channel.
 
 ```clojure
-(let [response-promise (request-factorial 5)]
-  @response-promise ;;=> 120
+(let [response-ch (request-factorial 5)]
+  (async/<!! response-ch)) ;;=> 120
 ```
 
 ## License

--- a/test/kehaar/core_test.clj
+++ b/test/kehaar/core_test.clj
@@ -34,5 +34,5 @@
   (let [c (async/chan)
         response-fn (ch->response-fn c)
         message {:test true}
-        response-promise (response-fn message)]
-    (is (= [response-promise message] (async/<!! c)))))
+        response-channel (response-fn message)]
+    (is (= [response-channel message] (async/<!! c)))))

--- a/test/kehaar/rabbit_mq_test.clj
+++ b/test/kehaar/rabbit_mq_test.clj
@@ -35,8 +35,8 @@
     (wire-up-service ch rabbit-queue chan)
 
     (let [message {:testing "wire-up"}
-          response-promise (response-fn message)
-          response @response-promise]
+          response-chan (response-fn message)
+          response (async/<!! response-chan)]
       (is (= response (str message))))
 
     (rmq/close ch)


### PR DESCRIPTION
This reverts commit c748a4b2190fa2aae3937e3066861c3a766bbaeb.

We decided it was better to return a core.async channel after all.

Example use case: Consuming the responses in a go block allows the go
block's thread to park when using a channel, but it will block and tie
up the thread if you're using a promise.

Is this the cleanest way to do this (in git)? I'm conflicted. Maybe this is a good example of why changelog edits should be their own commits?