### PR TITLE
Wiring helpers to shorten + clarify queue declarations.

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,10 +62,10 @@ patterns:
 
 ```
 (let [ch (incoming-events-channel conn
-                          "my-service.events.create-something"
-                          (config :queues "my-service.events.create-something")
-                          "create-something"
-                          create-something-events)] ;; events core.async channel
+                                  "my-service.events.create-something"
+                                  (config :queues "my-service.events.create-something")
+                                  "create-something"
+                                  create-something-events)] ;; events core.async channel
   ;; later, on exit, close ch
   (rmq/close ch))
 ```
@@ -75,9 +75,9 @@ patterns:
 
 ```
 (let [ch (outgoing-events-channel conn
-                          "events"
-                          "create-something"
-                          create-something-events)] ;; events core.async channel
+                                  "events"
+                                  "create-something"
+                                  create-something-events)] ;; events core.async channel
   ;; later, on exit, close ch
   (rmq/close ch))
 ```

--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ of the low-level RabbitMQ channel and queue management for you.
 
 ## High-level interface
 
+```
+(require '[kehaar.wire-up :as wire-up])
+```
+
 The patterns of services we use in Kraken fall into one of these
 patterns:
 
@@ -23,9 +27,9 @@ patterns:
 
 ```
 (let [ch (declare-events-exchange conn
-                                   "events"
-                                   "topic"
-                                   (config :topics "events"))]
+                                  "events"
+                                  "topic"
+                                  (config :topics "events"))]
   ;; later, on exit, close ch
   (rmq/close ch))
 ```
@@ -37,8 +41,7 @@ patterns:
 (let [ch (external-service-channel conn
                                    "service-works.service.process"
                                    (config :queues "service-works.service.process")
-                                   process-channel ;; a core.async channel
-                                   )]
+                                   process-channel)] ;; a core.async channel
   ;; later, on exit, close ch
   (rmq/close ch))
 ```
@@ -49,8 +52,7 @@ patterns:
 (let [ch (incoming-service-handler conn
                                    "service-works.service.process"
                                    (config :queues "service-works.service.process")
-                                   handler ;; a handler function
-                                   )]
+                                   handler)] ;; a handler function
   ;; later, on exit, close ch
   (rmq/close ch))
 ```
@@ -63,8 +65,7 @@ patterns:
                           "my-service.events.create-something"
                           (config :queues "my-service.events.create-something")
                           "create-something"
-                          create-something-events ;; events core.async channel
-                          )]
+                          create-something-events)] ;; events core.async channel
   ;; later, on exit, close ch
   (rmq/close ch))
 ```
@@ -76,8 +77,7 @@ patterns:
 (let [ch (outgoing-events-channel conn
                           "events"
                           "create-something"
-                          create-something-events ;; events core.async channel
-                          )]
+                          create-something-events)] ;; events core.async channel
   ;; later, on exit, close ch
   (rmq/close ch))
 ```

--- a/README.md
+++ b/README.md
@@ -8,6 +8,82 @@ A Clojure library designed to pass messages between RabbitMQ and core.async.
 
 Add `[democracyworks/kehaar "0.3.0"]` to your dependencies.
 
+There are two ways to use Kehaar. Functions in `kehaar.core` are a
+low-level interface to connect up Rabbit and core.async. Functions in
+`kehaar.wire-up` use these low-level functions but also will do a lot
+of the low-level RabbitMQ channel and queue management for you.
+
+## High-level interface
+
+The patterns of services we use in Kraken fall into one of these
+patterns:
+
+* You want to listen for events on the events exchange. So you'll need
+  to declare it first.
+
+```
+(let [ch (declare-events-exchange conn
+                                   "events"
+                                   "topic"
+                                   (config :topics "events"))]
+  ;; later, on exit, close ch
+  (rmq/close ch))
+```
+
+* You want to connect to an external query-response service over
+  RabbitMQ.
+
+```
+(let [ch (external-service-channel conn
+                                   "service-works.service.process"
+                                   (config :queues "service-works.service.process")
+                                   process-channel ;; a core.async channel
+                                   )]
+  ;; later, on exit, close ch
+  (rmq/close ch))
+```
+
+* You want to make an query-response service based on a handler.
+
+```
+(let [ch (incoming-service-handler conn
+                                   "service-works.service.process"
+                                   (config :queues "service-works.service.process")
+                                   handler ;; a handler function
+                                   )]
+  ;; later, on exit, close ch
+  (rmq/close ch))
+```
+
+* You want to listen for events on the events exchange. (First declare
+  the exchange above, only do that once.)
+
+```
+(let [ch (incoming-events-channel conn
+                          "my-service.events.create-something"
+                          (config :queues "my-service.events.create-something")
+                          "create-something"
+                          create-something-events ;; events core.async channel
+                          )]
+  ;; later, on exit, close ch
+  (rmq/close ch))
+```
+
+* You want to send events on the events exchange. (First declare the
+  exchange above, only do that once.)
+
+```
+(let [ch (outgoing-events-channel conn
+                          "events"
+                          "create-something"
+                          create-something-events ;; events core.async channel
+                          )]
+  ;; later, on exit, close ch
+  (rmq/close ch))
+```
+
+## Low-level interface
+
 ### Passing messages from RabbitMQ to core.async
 
 ```clojure

--- a/src/kehaar/wire_up.clj
+++ b/src/kehaar/wire_up.clj
@@ -16,7 +16,7 @@
     (kehaar.core/responder ch queue-name handler)
     ch))
 
-(defn incoming-events
+(defn incoming-events-channel
   "Wire up a channel that will receive incoming events that match
   `routing-key`.
 

--- a/src/kehaar/wire_up.clj
+++ b/src/kehaar/wire_up.clj
@@ -1,0 +1,57 @@
+(ns kehaar.wire-up
+  (:require
+   [langohr.queue]
+   [langohr.channel]
+   [langohr.exchange]
+   [kehaar.core]))
+
+(defn incoming-service-handler
+  "Wire up a handler to a queue. The handler will receive kehaar
+  messages as per `kehaar.core/responder`.
+
+  Returns a langohr channel. Please close it on exit."
+  [connection queue-name options handler]
+  (let [ch (langohr.channel/open connection)]
+    (langohr.queue/declare ch queue-name options)
+    (kehaar.core/responder ch queue-name handler)
+    ch))
+
+(defn incoming-events
+  "Wire up a channel that will receive incoming events that match
+  `routing-key`.
+
+  Returns a langohr channel. Please close it on exit."
+  [connection queue-name options routing-key channel]
+  (let [ch (langohr.channel/open connection)
+        queue (:queue (langohr.queue/declare ch queue-name options))]
+    (langohr.queue/bind ch queue "events" {:routing-key routing-key})
+    (kehaar.core/rabbit->async ch queue channel)
+    ch))
+
+(defn external-service-channel
+  "Wire up a channel to call an external service.
+
+  Returns a langohr channel. Please close it on exit."
+  [connection queue-name options channel]
+  (let [ch (langohr.channel/open connection)]
+    (langohr.queue/declare ch queue-name options)
+    (kehaar.core/wire-up-service ch queue-name channel)
+    ch))
+
+(defn outgoing-events-channel
+  "Wire up a queue listening to a channel for events.
+
+  Returns a langohr channel. Please close it on exit."
+  [connection topic-name routing-key channel]
+  (let [ch (langohr.channel/open connection)]
+    (kehaar.core/async->rabbit channel ch topic-name routing-key)
+    ch))
+
+(defn declare-events-exchange
+  "Declare an events exchange.
+
+  Returns a langohr channel. Please close it on exit."
+  [connection name type options]
+  (let [ch (langohr.channel/open connection)]
+    (langohr.exchange/declare ch name type options)
+    ch))


### PR DESCRIPTION
Our creation and wiring up of queues, handlers, and channels was getting
hairy. We had several patterns that we were repeating across
projects. These functions codify those patterns with descriptive
names. The goal is to make it easier to write and read queue wire-ups.

All of these functions are in the `kehaar.wire-up` namespace, intended
to be aliased as `wire-up`. That makes their usage read like
English. Example:

```
(wire-up/incoming-service-handler ...)
(wire-up/incoming-events ...)
```

All of these wire-up functions return the langohr channel they opened.