### PR TITLE
add connect-to-broker fn

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## Changes between Kehaar 0.4.0 and HEAD
+
+Added `kehaar.rabbitmq/connect-with-retries` function to make connecting to
+RabbitMQ brokers more robust.
+
 ## Changes between Kehaar 0.3.0 and 0.4.0
 
 ### kehaar.core/ch->response-fn

--- a/README.md
+++ b/README.md
@@ -160,6 +160,20 @@ All messages sent to the `outgoing-messages` channel will ebe ncoded
 as edn and placed on the queue specified in the `:reply-to` key in the
 metadata. Each message should have `:message` and `:metadata`.
 
+### Connecting to RabbitMQ
+
+While it is perfectly acceptable to connect to RabbitMQ using langohr directly,
+there is also `kehaar.rabbitmq/connect-with-retries`. This fn takes a RabbitMQ
+config map just like `langohr.core/connect` or that and a max-retry count
+(which defaults to 5 if ommitted).
+
+It then attempts to connect to the RabbitMQ broker up to the max-retry count
+with backoff of `(* attempts 1000)` milliseconds.
+
+If it fails to connect to the broker after hitting the maximum number of retries,
+it will return nil. If it succeeds, it will return the connection just like
+`langohr.core/connect`.
+
 ## License
 
 Copyright © 2015 Democracy Works, Inc.

--- a/README.md
+++ b/README.md
@@ -171,8 +171,8 @@ It then attempts to connect to the RabbitMQ broker up to the max-retry count
 with backoff of `(* attempts 1000)` milliseconds.
 
 If it fails to connect to the broker after hitting the maximum number of retries,
-it will return nil. If it succeeds, it will return the connection just like
-`langohr.core/connect`.
+it will re-throw the final `java.net.ConnectException` from `langohr.core/connect`.
+If it succeeds, it will return the connection just like `langohr.core/connect`.
 
 ## License
 

--- a/src/kehaar/core.clj
+++ b/src/kehaar/core.clj
@@ -1,29 +1,11 @@
 (ns kehaar.core
   (:require [clojure.core.async :as async]
             [clojure.edn :as edn]
-            [langohr.core :as rmq]
             [langohr.basic :as lb]
             [langohr.consumers :as lc]
             [langohr.queue :as lq]
             [clojure.tools.logging :as log]
             [kehaar.async :refer [bounded>!!]]))
-
-(defn connect-to-broker
-  "Attempts to connect to RabbitMQ broker `tries` times.
-  Returns connection if successful, nil if not."
-  ([config] (connect-to-broker config 5))
-  ([config tries]
-   (loop [attempt 1]
-     (if-let [connection (try
-                           (rmq/connect config)
-                           (catch Throwable t
-                             (log/warn "RabbitMQ not available:" (.getMessage t) "attempt:" attempt)
-                             nil))]
-       (do (log/info "RabbitMQ connected.")
-           connection)
-       (when (< attempt tries)
-         (Thread/sleep (* attempt 1000))
-         (recur (inc attempt)))))))
 
 (defn read-payload
   "Unsafely read a byte array as edn."

--- a/src/kehaar/core.clj
+++ b/src/kehaar/core.clj
@@ -1,10 +1,31 @@
 (ns kehaar.core
   (:require [clojure.core.async :as async]
             [clojure.edn :as edn]
+            [langohr.core :as rmq]
             [langohr.basic :as lb]
             [langohr.consumers :as lc]
             [langohr.queue :as lq]
             [clojure.tools.logging :as log]))
+
+(defn connect-to-broker
+  "Attempts to connect to RabbitMQ broker `tries` times.
+  Returns connection if successful, nil if not."
+  ([config] (connect-to-broker config 5))
+  ([config tries]
+   (let [connection (atom nil)]
+     (loop [attempt 1]
+       (try
+         (reset! connection
+                 (rmq/connect config))
+         (log/info "RabbitMQ connected.")
+         (catch Throwable t
+           (log/warn "RabbitMQ not available:" (.getMessage t) "attempt:" attempt)))
+       (if (nil? @connection)
+         (if (< attempt tries)
+           (do (Thread/sleep (* attempt 1000))
+               (recur (inc attempt)))
+           nil)
+         @connection)))))
 
 (defn read-payload [^bytes payload]
   (-> payload

--- a/src/kehaar/rabbitmq.clj
+++ b/src/kehaar/rabbitmq.clj
@@ -10,8 +10,8 @@
    (loop [attempt 1]
      (if-let [connection (try
                            (connect config)
-                           (catch Throwable t
-                             (log/warn "RabbitMQ not available:" (.getMessage t) "attempt:" attempt)
+                           (catch java.net.ConnectException ce
+                             (log/warn "RabbitMQ not available:" (.getMessage ce) "attempt:" attempt)
                              nil))]
        (do (log/info "RabbitMQ connected.")
            connection)

--- a/src/kehaar/rabbitmq.clj
+++ b/src/kehaar/rabbitmq.clj
@@ -1,0 +1,20 @@
+(ns kehaar.rabbitmq
+  (:require [langohr.core :refer [connect]]
+            [clojure.tools.logging :as log]))
+
+(defn connect-to-broker
+  "Attempts to connect to RabbitMQ broker `tries` times.
+  Returns connection if successful, nil if not."
+  ([config] (connect-to-broker config 5))
+  ([config tries]
+   (loop [attempt 1]
+     (if-let [connection (try
+                           (connect config)
+                           (catch Throwable t
+                             (log/warn "RabbitMQ not available:" (.getMessage t) "attempt:" attempt)
+                             nil))]
+       (do (log/info "RabbitMQ connected.")
+           connection)
+       (when (< attempt tries)
+         (Thread/sleep (* attempt 1000))
+         (recur (inc attempt)))))))

--- a/src/kehaar/rabbitmq.clj
+++ b/src/kehaar/rabbitmq.clj
@@ -4,7 +4,7 @@
 
 (defn connect-with-retries
   "Attempts to connect to RabbitMQ broker `tries` times.
-  Returns connection if successful, nil if not."
+  Returns connection if successful."
   ([config] (connect-with-retries config 5))
   ([config tries]
    (loop [attempt 1]
@@ -12,9 +12,10 @@
                            (connect config)
                            (catch java.net.ConnectException ce
                              (log/warn "RabbitMQ not available:" (.getMessage ce) "attempt:" attempt)
-                             nil))]
+                             (when (>= attempt tries)
+                               (throw ce))))]
        (do (log/info "RabbitMQ connected.")
            connection)
-       (when (< attempt tries)
+       (do
          (Thread/sleep (* attempt 1000))
          (recur (inc attempt)))))))

--- a/src/kehaar/rabbitmq.clj
+++ b/src/kehaar/rabbitmq.clj
@@ -2,10 +2,10 @@
   (:require [langohr.core :refer [connect]]
             [clojure.tools.logging :as log]))
 
-(defn connect-to-broker
+(defn connect-with-retries
   "Attempts to connect to RabbitMQ broker `tries` times.
   Returns connection if successful, nil if not."
-  ([config] (connect-to-broker config 5))
+  ([config] (connect-with-retries config 5))
   ([config tries]
    (loop [attempt 1]
      (if-let [connection (try

--- a/test/kehaar/rabbit_mq_test.clj
+++ b/test/kehaar/rabbit_mq_test.clj
@@ -8,7 +8,8 @@
             [langohr.basic :as lb]
             [langohr.consumers :as lc]
             [clojure.tools.logging :as log]
-            [kehaar.async :refer [bounded<!! bounded>!!]]))
+            [kehaar.async :refer [bounded<!! bounded>!!]]
+            [kehaar.rabbitmq :refer [connect-to-broker]]))
 
 (deftest ^:rabbit-mq connect-to-broker-test
   (testing "connects to running broker and returns connection"

--- a/test/kehaar/rabbit_mq_test.clj
+++ b/test/kehaar/rabbit_mq_test.clj
@@ -9,14 +9,14 @@
             [langohr.consumers :as lc]
             [clojure.tools.logging :as log]
             [kehaar.async :refer [bounded<!! bounded>!!]]
-            [kehaar.rabbitmq :refer [connect-to-broker]]))
+            [kehaar.rabbitmq :refer [connect-with-retries]]))
 
-(deftest ^:rabbit-mq connect-to-broker-test
+(deftest ^:rabbit-mq connect-with-retries-test
   (testing "connects to running broker and returns connection"
-    (is (= (class (connect-to-broker {}))
+    (is (= (class (connect-with-retries {}))
            com.novemberain.langohr.Connection)))
   (testing "returns nil when broker unavailable"
-    (is (nil? (connect-to-broker {:host "localhost" :port 65535} 1)))))
+    (is (nil? (connect-with-retries {:host "localhost" :port 65535} 1)))))
 
 (deftest ^:rabbit-mq async=>rabbit-rabbit=>async-test
   (let [conn (rmq/connect)

--- a/test/kehaar/rabbit_mq_test.clj
+++ b/test/kehaar/rabbit_mq_test.clj
@@ -8,6 +8,13 @@
             [langohr.basic :as lb]
             [langohr.consumers :as lc]))
 
+(deftest ^:rabbit-mq connect-to-broker-test
+  (testing "connects to running broker and returns connection"
+    (is (= (class (connect-to-broker {}))
+           com.novemberain.langohr.Connection)))
+  (testing "returns nil when broker unavailable"
+    (is (nil? (connect-to-broker {:host "localhost" :port 65535} 1)))))
+
 (deftest ^:rabbit-mq async->rabbit-rabbit->async-test
   (let [conn (rmq/connect)
         ch (lch/open conn)

--- a/test/kehaar/rabbit_mq_test.clj
+++ b/test/kehaar/rabbit_mq_test.clj
@@ -15,8 +15,9 @@
   (testing "connects to running broker and returns connection"
     (is (= (class (connect-with-retries {}))
            com.novemberain.langohr.Connection)))
-  (testing "returns nil when broker unavailable"
-    (is (nil? (connect-with-retries {:host "localhost" :port 65535} 1)))))
+  (testing "throws exception when broker unavailable"
+    (is (thrown? java.net.ConnectException
+                 (connect-with-retries {:host "localhost" :port 65535} 1)))))
 
 (deftest ^:rabbit-mq async=>rabbit-rabbit=>async-test
   (let [conn (rmq/connect)


### PR DESCRIPTION
This moves some boilerplate code we've been repeating in every kehaar project into the library itself.

Between this and @ericnormand's new `wire-up` ns, it makes the `queue/initialize` fn much shorter. Here's a before and after from a new kraken-works component:

## Before
```clojure
(ns new-kraken-works.queue
  (:require [langohr.core :as rmq]
            [langohr.channel :as lch]
            [langohr.queue :as lq]
            [kehaar.core :as k]
            [clojure.tools.logging :as log]))

(defn initialize []
  (let [connection (atom nil)
        max-retries 5]
    (loop [attempt 1]
      (try
        (reset! connection
                (rmq/connect (or (config :rabbitmq :connection)
                                 {})))
        (log/info "RabbitMQ connected.")
        (catch Throwable t
          (log/warn "RabbitMQ not available:" (.getMessage t) "attempt:" attempt)))
      (when (nil? @connection)
        (if (< attempt max-retries)
          (do (Thread/sleep (* attempt 1000))
              (recur (inc attempt)))
          (do (log/error "Connecting to RabbitMQ failed. Bailing.")
              (throw (ex-info "Connecting to RabbitMQ failed" {:attempts attempt}))))))
    (let [ok-ch (lch/open @connection)]
      (lq/declare ok-ch
                  "voter-registration-works.ok"
                  (config :rabbitmq :queues "voter-registration-works.ok"))
      (k/responder ok-ch "voter-registration-works.ok" handlers/ok)
      {:connections [@connection]
       :channels [ok-ch]})))
```

## After
```clojure
(ns new-kraken-works.queue
  (:require [kehaar.core :as k]
            [kehaar.wire-up :as wire-up]
            [clojure.tools.logging :as log]))

(defn initialize []
  (let [max-connection-attempts 5
        connection (k/connect-to-broker (config [:rabbitmq :connection] {})
                                        max-connection-attempts)]
    (when (nil? connection)
      (log/error "Connecting to RabbitMQ failed. Bailing.")
      (throw (ex-info "Connecting to RabbitMQ failed" {:attempts max-connection-attempts})))
    {:connections [connection]
     :channels [(wire-up/incoming-service-handler
                 connection
                 "voter-registration-works.ok"
                 (config [:rabbitmq :queues "voter-registration-works.ok"])
                 handlers/ok)]}))
```

Assigning to @tank157 but I imagine @tie-rack will want to weigh in too.