### PR TITLE
Backpressure

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,23 +38,30 @@ patterns:
   RabbitMQ.
 
 ```
-(let [ch (external-service-channel conn
-                                   "service-works.service.process"
-                                   (config :queues "service-works.service.process")
-                                   process-channel)] ;; a core.async channel
+(let [ch (external-service conn
+                           "service-works.service.process"
+                           process-channel)] ;; a core.async channel
   ;; later, on exit, close ch
   (rmq/close ch))
 ```
 
-* You want to make an query-response service based on a handler.
+* You want to make a query-response service. Send requests to
+  in-channel and get responses on out-channel (core.async channels).
 
 ```
-(let [ch (incoming-service-handler conn
-                                   "service-works.service.process"
-                                   (config :queues "service-works.service.process")
-                                   handler)] ;; a handler function
+(let [ch (incoming-service conn
+                           "service-works.service.process"
+                           (config :queues "service-works.service.process")
+                           in-channel
+                           out-channel)]
   ;; later, on exit, close ch
   (rmq/close ch))
+```
+
+Later, you can add a handler to it like this:
+
+```
+(start-responder! in-channel out-channel handler-function)
 ```
 
 * You want to listen for events on the events exchange. (First declare
@@ -65,9 +72,16 @@ patterns:
                                   "my-service.events.create-something"
                                   (config :queues "my-service.events.create-something")
                                   "create-something"
-                                  create-something-events)] ;; events core.async channel
+                                  create-something-events ;; events core.async channel
+                                  100)] ;; timeout
   ;; later, on exit, close ch
   (rmq/close ch))
+```
+
+Later, you can add an event handler like this:
+
+```
+(start-event-handler! in-channel handler-function)
 ```
 
 * You want to send events on the events exchange. (First declare the
@@ -93,14 +107,14 @@ patterns:
 
 (def messages-from-rabbit (async/chan))
 
-(k/rabbit->async a-rabbit-channel
+(k/rabbit=>async a-rabbit-channel
                  "watership"
                  messages-from-rabbit)
 ```
 
 edn-encoded payloads on the "watership" queue will be decoded and
 placed on the `messages-from-rabbit` channel for you to deal with as
-you like.
+you like. Each message has `:message` and `:metadata`.
 
 ### Passing messages from core.async to RabbitMQ
 
@@ -111,61 +125,31 @@ you like.
 
 (def outgoing-messages (async/chan))
 
-(k/async->rabbit outgoing-messages
+(k/async=>rabbit outgoing-messages
                  a-rabbit-channel
                  "updates")
 ```
 
 All messages sent to the `outgoing-messages` channel will encoded as
-edn and placed on the "updates" queue.
+edn and placed on the "updates" queue. Each message should have
+`:message` and `:metadata`.
 
-### Applying a function to all messages on a RabbitMQ queue and responding on the reply-to queue with a correlation ID.
-
-```clojure
-(ns example
-  (:require [kehaar.core :as k]
-            [langohr.consumers :as lc]))
-
-(defn factorial [n]
-  (reduce * 1 (range 1 (inc n))))
-
-(k/responder a-rabbit-channel
-             "get-factorial"
-             factorial)
-```
-
-edn-encoded payloads on the "get-factorial" queue will be decoded and
-passed to the `factorial` function and the result will be encoded as
-edn and delivered to the reply-to queue with the correlation ID.
-
-### Using core.async channels to enqueue and receive replies to a RabbitMQ queue
+### Passing messages from core.async to RabbitMQ based on reply-to
 
 ```clojure
 (ns example
-  (:require [kehaar.core :as k]
-            [clojure.core.async :as async]))
+  (:require [core.async :as async]
+            [kehaar.core :as k]))
 
-(def factorial-ch (async/chan))
-(def request-factorial (k/ch->response-fn factorial-ch))
+(def outgoing-messages (async/chan))
 
-(k/wire-up-service a-rabbit-channel
-                   "get-factorial"
-                   factorial-ch)
+(k/async=>rabbit-with-reply-to outgoing-messages
+                               a-rabbit-channel)
 ```
 
-Calling `(request-factorial 5)` will return a core.async channel for
-you to listen for the result from the "get-factorial"
-queue. `wire-up-service` listens on `factorial-ch` for messages,
-creates a response channel, sends a message to the "get-factorial"
-queue with a correlation ID, listens on a reply-to queue, and finally
-puts the response (edn-decoded, naturally) onto the response
-channel. The reply-to queue must receive a reply within 1000ms,
-otherwise it will close the response channel.
-
-```clojure
-(let [response-ch (request-factorial 5)]
-  (async/<!! response-ch)) ;;=> 120
-```
+All messages sent to the `outgoing-messages` channel will ebe ncoded
+as edn and placed on the queue specified in the `:reply-to` key in the
+metadata. Each message should have `:message` and `:metadata`.
 
 ## License
 

--- a/src/kehaar/async.clj
+++ b/src/kehaar/async.clj
@@ -1,0 +1,14 @@
+(ns kehaar.async
+  (:require [clojure.core.async :as async]))
+
+(defn bounded>!!
+  "Like async/>!, but with a timeout."
+  [channel message timeout]
+  (async/alt!!
+    [[channel message]] true
+    (async/timeout timeout) false))
+
+(defn bounded<!! [channel timeout]
+  (async/alt!!
+    channel ([v] v)
+    (async/timeout timeout) ([] (throw (ex-info "<!! timeout out" {})))))

--- a/src/kehaar/core.clj
+++ b/src/kehaar/core.clj
@@ -4,117 +4,147 @@
             [langohr.basic :as lb]
             [langohr.consumers :as lc]
             [langohr.queue :as lq]
-            [clojure.tools.logging :as log]))
+            [clojure.tools.logging :as log]
+            [kehaar.async :refer [bounded>!!]]))
 
-(defn read-payload [^bytes payload]
+(defn read-payload
+  "Unsafely read a byte array as edn."
+  [^bytes payload]
   (-> payload
       (String. "UTF-8")
       edn/read-string))
 
-(defn rabbit->async-handler-fn
-  "Returns a RabbitMQ message handler function which forwards all
-  message payloads to `channel`. Assumes that all payloads are UTF-8
-  edn strings. Returned fn returns the message delivery tag."
-  [channel]
-  (fn [ch {:keys [delivery-tag]} ^bytes payload]
-    (let [message (read-payload payload)]
-      (log/debug "Kehaar: Consuming message" (str "(delivery-tag " delivery-tag "): ") (pr-str message))
-      (async/>!! channel message)
-      (log/debug "Kehaar: Successfully forwarded message" (str "(delivery-tag " delivery-tag ")") "to core.async channel")
-      delivery-tag)))
+(defn channel-handler
+  "Returns a RabbitMQ message handler function which puts each
+  incoming message on `channel`."
+  ([channel exchange timeout]
+   (fn [ch {:keys [delivery-tag] :as metadata} ^bytes payload]
+     (try
+       (let [message (read-payload payload)]
+         (if (nil? message)
+           ;; don't requeue nil, it's invalid
+           [:nack delivery-tag false]
+           (if (bounded>!! channel {:message  message
+                                    :metadata metadata} timeout)
+             ;; successfully put, ack now
+             [:ack delivery-tag]
+             ;; assume we're busy, requeue timed out
+             [:nack delivery-tag true])))
+       (catch Throwable t
+         (log/error t "fn->handler-fn: payload did not parse"
+                    (String. payload "UTF-8"))
+         ;; don't requeue parse errors
+         [:nack delivery-tag false])))))
 
-(defn rabbit->async
+(defn- ack-or-nack [channel [op delivery-tag requeue :as ret]]
+  (case op
+    :ack  (lb/ack  channel delivery-tag)
+    :nack (lb/nack channel delivery-tag false requeue)
+    ;; otherwise, let's log that
+    (log/warn "I don't know how to process this:" ret
+              "I'm designed to process messages containing :ack or :nack.")))
+
+(defn rabbit=>async
   "Subscribes to the RabbitMQ queue, taking each payload, decoding as
-  edn, and putting the result onto the async channel."
+  edn, and putting the result onto the async channel. This propagates
+  backpressure back to rabbit by using nacks."
   ([rabbit-channel queue channel]
-   (rabbit->async rabbit-channel queue channel {}))
-  ([rabbit-channel queue channel options]
+   (rabbit=>async rabbit-channel queue channel {} 100))
+  ([rabbit-channel queue channel options timeout]
    (lc/subscribe rabbit-channel
                  queue
-                 (comp (partial lb/ack rabbit-channel)
-                       (rabbit->async-handler-fn channel))
+                 (comp (partial ack-or-nack rabbit-channel)
+                       (channel-handler channel "" timeout))
                  (merge options {:auto-ack false}))))
 
-(defn async->rabbit
-  "Forward all messages on channel to the RabbitMQ queue."
-  ([channel rabbit-channel queue]
-   (async->rabbit channel rabbit-channel "" queue))
-  ([channel rabbit-channel exchange queue]
-   (async/go-loop []
-     (let [message (async/<! channel)]
-       (if (nil? message)
-         (log/warn "Kehaar: core.async channel for" queue "is closed")
-         (do (lb/publish rabbit-channel exchange queue (pr-str message))
+(defmacro go-handler
+  "A macro that runs code in `body`, with `binding` bound to each
+  message coming in on `channel`."
+  [[binding channel] & body]
+  `(let [channel# ~channel]
+     (async/go-loop []
+       (let [ch-message# (async/<! channel#)]
+         (if (nil? ch-message#)
+           (log/warn "Kehaar: go handler is closed.")
+           (do
+             (try
+               (let [~binding ch-message#]
+                 ~@body)
+               (catch Throwable t#
+                 (log/error t#)))
              (recur)))))))
 
-(defn fn->handler-fn
-  "Returns a RabbitMQ message handler function which calls f for each
-  incoming message and replies on the reply-to queue with the
-  response."
-  ([f] (fn->handler-fn f ""))
-  ([f exchange]
-   (fn [ch {:keys [reply-to correlation-id]} ^bytes payload]
-     (let [message (read-payload payload)
-           response (f message)]
-       (lb/publish ch exchange reply-to (pr-str response)
-                   {:correlation-id correlation-id})))))
+(defn async=>rabbit
+  "Forward all messages on channel to the RabbitMQ queue. Messages
+  should look like:
 
-(defn responder
-  "Given a RabbitMQ queue and a function, subscribes to that queue,
-  calling the function on each edn-decoded message, and replies to the
-  reply-to queue with the result."
-  ([rabbit-channel queue f]
-   (responder rabbit-channel queue f {:auto-ack true}))
-  ([rabbit-channel queue f opts]
-   (let [handler-fn (fn->handler-fn f)]
-     (lc/subscribe rabbit-channel
-                   queue
-                   handler-fn
-                   opts))))
+  ```
+  {:message  {...}  ;; message payload
+  :metadata {...}} ;; rabbit metadata
+  ```"
+  ([channel rabbit-channel queue]
+   (async=>rabbit channel rabbit-channel "" queue))
+  ([channel rabbit-channel exchange queue]
+   (go-handler [{:keys [message metadata]} channel]
+               (lb/publish rabbit-channel exchange queue (pr-str message) metadata))))
 
-(defn ch->response-fn
+(defn async=>rabbit-with-reply-to
+  "Forward all messages on channel to the RabbitMQ queue specified in
+  `:reply-to` metadata. Messages should look like:
+
+  ```
+  {:message  {...}  ;; message payload
+  :metadata {:repy-to \"queue\"
+  ...}} ;; rabbit metadata
+  ```"
+  ([channel rabbit-channel]
+   (async=>rabbit-with-reply-to channel rabbit-channel ""))
+  ([channel rabbit-channel exchange]
+   (go-handler [{:keys [message metadata]} channel]
+    (if-let [reply-to (:reply-to metadata)]
+      (lb/publish rabbit-channel exchange (:reply-to metadata) (pr-str message) metadata)
+      (log/warn "No reply-to in metadata."
+                (pr-str message)
+                (pr-str metadata))))))
+
+(defn thread-handler
+  [channel f]
+  (async/thread
+    (loop []
+      (let [ch-message (async/<!! channel)]
+        (if (nil? ch-message)
+          (log/warn "Kehaar: thread handler is closed.")
+          (do
+            (try
+              (f ch-message)
+              (catch Throwable t
+                (log/error t)))
+            (recur)))))))
+
+(defn responder-fn
+  "Create a function that takes map of message and metadata, calls `f`
+  on message, and redirects the return to `out-channel`. This is used
+  by `responder`. Handles two cases: async channel return and regular
+  value return."
+  [out-channel f]
+  (fn [{:keys [message metadata]}]
+    (let [return (f message)]
+      (if (satisfies? clojure.core.async.impl.protocols/ReadPort return)
+        (let [metadata-channel (async/chan 1000 (map (fn [message]
+                                                       {:message message
+                                                        :metadata metadata})))]
+          (async/pipe return metadata-channel true)
+          (async/pipe metadata-channel out-channel false))
+
+        (async/>!! out-channel {:message return
+                                :metadata metadata})))))
+
+(defn async->fn
   "Returns a fn that takes a message, creates a core.async channel for
   the response for that message, and puts [response-channel, message]
   on the channel given. Returns the response-channel."
   [channel]
   (fn [message]
-    (let [response-channel (async/chan)]
-      (async/go
-        (async/>! channel [response-channel message]))
+    (let [response-channel (async/chan 1)]
+      (async/>!! channel [response-channel message])
       response-channel)))
-
-(defn wire-up-service
-  "Wires up a core.async channel (managed through ch->response-fn) to
-  a RabbitMQ queue that provides responses."
-  ([rabbit-channel queue channel]
-   (wire-up-service rabbit-channel ""
-                    queue {:exclusive false :auto-delete true}
-                    1000 channel))
-  ([rabbit-channel exchange queue queue-options timeout channel]
-   (let [response-queue (lq/declare-server-named rabbit-channel {:exclusive true :auto-delete true})
-         pending-calls (atom {})]
-     (lc/subscribe rabbit-channel
-                   response-queue
-                   (fn [ch {:keys [correlation-id]} ^bytes payload]
-                     (when-let [response-channel (@pending-calls correlation-id)]
-                       (async/go
-                         (async/>! response-channel (read-payload payload)))
-                       (swap! pending-calls dissoc correlation-id)))
-                   {:auto-ack true})
-     (async/go-loop []
-       (let [ch-message (async/<! channel)]
-         (if (nil? ch-message)
-           (log/warn "Kehaar: core.async channel for" queue "is closed")
-           (let [[response-channel message] ch-message
-                 correlation-id (str (java.util.UUID/randomUUID))]
-             (swap! pending-calls assoc correlation-id response-channel)
-             (lb/publish rabbit-channel
-                         exchange
-                         queue
-                         (pr-str message)
-                         {:reply-to response-queue
-                          :correlation-id correlation-id})
-             (async/go
-               (async/<! (async/timeout timeout))
-               (swap! pending-calls dissoc correlation-id))
-             (recur))))))))

--- a/src/kehaar/core.clj
+++ b/src/kehaar/core.clj
@@ -80,7 +80,7 @@
 
   ```
   {:message  {...}  ;; message payload
-  :metadata {...}} ;; rabbit metadata
+  :metadata {...}} ;; rabbit metadata (optional)
   ```"
   ([channel rabbit-channel queue]
    (async=>rabbit channel rabbit-channel "" queue))

--- a/src/kehaar/core.clj
+++ b/src/kehaar/core.clj
@@ -139,12 +139,4 @@
         (async/>!! out-channel {:message return
                                 :metadata metadata})))))
 
-(defn async->fn
-  "Returns a fn that takes a message, creates a core.async channel for
-  the response for that message, and puts [response-channel, message]
-  on the channel given. Returns the response-channel."
-  [channel]
-  (fn [message]
-    (let [response-channel (async/chan 1)]
-      (async/>!! channel [response-channel message])
-      response-channel)))
+

--- a/src/kehaar/core.clj
+++ b/src/kehaar/core.clj
@@ -31,7 +31,7 @@
              ;; assume we're busy, requeue timed out
              [:nack delivery-tag true])))
        (catch Throwable t
-         (log/error t "fn->handler-fn: payload did not parse"
+         (log/error t "Kehaar: fn->handler-fn: payload did not parse"
                     (String. payload "UTF-8"))
          ;; don't requeue parse errors
          [:nack delivery-tag false])))))
@@ -41,7 +41,7 @@
     :ack  (lb/ack  channel delivery-tag)
     :nack (lb/nack channel delivery-tag false requeue)
     ;; otherwise, let's log that
-    (log/warn "I don't know how to process this:" ret
+    (log/warn "Kehaar: I don't know how to process this:" ret
               "I'm designed to process messages containing :ack or :nack.")))
 
 (defn rabbit=>async
@@ -71,7 +71,7 @@
                (let [~binding ch-message#]
                  ~@body)
                (catch Throwable t#
-                 (log/error t#)))
+                 (log/error t# "Kehaar: caught an exception in go-handler")))
              (recur)))))))
 
 (defn async=>rabbit
@@ -103,7 +103,7 @@
    (go-handler [{:keys [message metadata]} channel]
     (if-let [reply-to (:reply-to metadata)]
       (lb/publish rabbit-channel exchange (:reply-to metadata) (pr-str message) metadata)
-      (log/warn "No reply-to in metadata."
+      (log/warn "Kehaar: No reply-to in metadata."
                 (pr-str message)
                 (pr-str metadata))))))
 
@@ -118,7 +118,7 @@
             (try
               (f ch-message)
               (catch Throwable t
-                (log/error t)))
+                (log/error t "Kehaar: caught exception in thread-handler")))
             (recur)))))))
 
 (defn responder-fn

--- a/src/kehaar/wire_up.clj
+++ b/src/kehaar/wire_up.clj
@@ -12,12 +12,12 @@
   `routing-key`.
 
   Returns a langohr channel. Please close it on exit."
-  [connection queue-name options exchange routing-key channel timeout]
+  [connection queue-name options topic-name routing-key channel timeout]
   (let [ch (langohr.channel/open connection)
         queue (:queue (langohr.queue/declare ch queue-name options))
         message-channel (async/chan 1 (map :message))]
     (async/pipe message-channel channel true)
-    (langohr.queue/bind ch queue exchange {:routing-key routing-key})
+    (langohr.queue/bind ch queue topic-name {:routing-key routing-key})
     (kehaar.core/rabbit=>async ch queue message-channel options timeout)
     ch))
 

--- a/src/kehaar/wire_up.clj
+++ b/src/kehaar/wire_up.clj
@@ -112,3 +112,13 @@
               (async/close! chan)
               (swap! pending-calls dissoc correlation-id))))))
      ch)))
+
+(defn async->fn
+  "Returns a fn that takes a message, creates a core.async channel for
+  the response for that message, and puts [response-channel, message]
+  on the channel given. Returns the response-channel."
+  [channel]
+  (fn [message]
+    (let [response-channel (async/chan 1)]
+      (async/>!! channel [response-channel message])
+      response-channel)))

--- a/src/kehaar/wire_up.clj
+++ b/src/kehaar/wire_up.clj
@@ -12,12 +12,12 @@
   `routing-key`.
 
   Returns a langohr channel. Please close it on exit."
-  [connection queue-name options routing-key channel timeout]
+  [connection queue-name options exchange routing-key channel timeout]
   (let [ch (langohr.channel/open connection)
         queue (:queue (langohr.queue/declare ch queue-name options))
         message-channel (async/chan 1 (map :message))]
     (async/pipe message-channel channel true)
-    (langohr.queue/bind ch queue "events" {:routing-key routing-key})
+    (langohr.queue/bind ch queue exchange {:routing-key routing-key})
     (kehaar.core/rabbit=>async ch queue message-channel options timeout)
     ch))
 

--- a/src/kehaar/wire_up.clj
+++ b/src/kehaar/wire_up.clj
@@ -24,8 +24,10 @@
 
   Returns a langohr channel. Please close it on exit."
   [connection topic-name routing-key channel]
-  (let [ch (langohr.channel/open connection)]
-    (kehaar.core/async=>rabbit channel ch topic-name routing-key)
+  (let [ch (langohr.channel/open connection)
+        message-channel (async/chan 1000 (map (fn [x] {:message x})))]
+    (async/pipe channel message-channel true)
+    (kehaar.core/async=>rabbit message-channel ch topic-name routing-key)
     ch))
 
 (defn declare-events-exchange

--- a/test/kehaar/core_test.clj
+++ b/test/kehaar/core_test.clj
@@ -1,7 +1,8 @@
 (ns kehaar.core-test
   (:require [clojure.test :refer :all]
             [kehaar.core :refer :all]
-            [clojure.core.async :as async]))
+            [clojure.core.async :as async]
+            [kehaar.async :refer [bounded<!! bounded>!!]]))
 
 (defn edn-bytes
   "Returns a byte array of the edn representation of x."
@@ -16,23 +17,60 @@
                :moon-landing #inst "1969-07-20"}
       rabbit-ch :rabbit-channel
       metadata {:year 2015 :delivery-tag 8675309}
-      payload (edn-bytes message)]
+      payload (edn-bytes message)
+      bad-payload (byte-array (map int "{"))
+      nil-payload (edn-bytes nil)]
 
   (deftest rabbit->async-handler-fn-test
     (let [c (async/chan 1)
-          handler (rabbit->async-handler-fn c)]
+          handler (channel-handler c "" 100)]
       (testing "only passes through the edn-decoded payload"
         (handler rabbit-ch metadata payload)
-        (let [returned-message (async/<!! c)]
-          (is (= returned-message message))))
+        (let [returned-message (bounded<!! c 100)]
+          (is (= message (:message returned-message)))))
       (testing "returns the delivery-tag metadata"
-        (is (= (:delivery-tag metadata)
+        (is (= [:ack (:delivery-tag metadata)]
                (handler rabbit-ch metadata payload)))
-        (async/<!! c)))))
+        (bounded<!! c 100))
 
-(deftest ch->response-fn-test
-  (let [c (async/chan)
-        response-fn (ch->response-fn c)
+      (testing "non-edn payload returns nack and puts nothing on channel"
+        (is (= [:nack (:delivery-tag metadata) false]
+               (handler rabbit-ch metadata bad-payload)))
+        (async/alt!!
+          c (is false "Bad payload should put nothing on channel.")
+          (async/timeout 100) (is true)))
+
+      (testing "nil payload returns nack and puts nothing on channel"
+        (is (= [:nack (:delivery-tag metadata) false]
+               (handler rabbit-ch metadata nil-payload)))
+        (async/alt!!
+          c (is false "Bad payload should put nothing on channel.")
+          (async/timeout 100) (is true))))))
+
+(deftest async->fn-test
+  (let [c (async/chan 1) ;; we need buffered channels for external services
+        response-fn (async->fn c)
         message {:test true}
         response-channel (response-fn message)]
     (is (= [response-channel message] (async/<!! c)))))
+
+(deftest responder-fn-test
+  (testing "can return a regular value"
+    (let [c (async/chan 1)
+          f (responder-fn c (fn [message]
+                              (* message 10)))]
+      (f {:message 10
+          :metadata :dude!})
+      (is (= {:message 100
+              :metadata :dude!}
+             (bounded<!! c 100)))))
+  (testing "can return a channel that will have the value"
+    (let [c (async/chan 1)
+          f (responder-fn c (fn [message]
+                              (async/go
+                                (* message 10))))]
+      (f {:message 10
+          :metadata :dude!})
+      (is (= {:message 100
+              :metadata :dude!}
+             (bounded<!! c 100))))))

--- a/test/kehaar/wire_up_test.clj
+++ b/test/kehaar/wire_up_test.clj
@@ -16,7 +16,7 @@
           ch-out (async/chan 1000)
           ch-in  (async/chan 1000)
           chs [(declare-events-exchange conn "events" "topic" {})
-               (incoming-events-channel conn "test-in" {} "test-event" ch-in 1000)
+               (incoming-events-channel conn "test-in" {} "events" "test-event" ch-in 1000)
                (outgoing-events-channel conn "events" "test-event" ch-out)]]
       (try
         (dotimes [x 1000]
@@ -36,7 +36,7 @@
           ch-out (async/chan 1000)
           ch-in  (async/chan 1000)
           chs [(declare-events-exchange conn "events" "topic" {})
-               (incoming-events-channel conn "test-in" {} "test-event" ch-in 1000)
+               (incoming-events-channel conn "test-in" {} "events" "test-event" ch-in 1000)
                (outgoing-events-channel conn "events" "test-event" ch-out)]]
       (try
         (let [messages (for [x (range 1000)
@@ -59,7 +59,7 @@
           ch-in  (async/chan 1000)
           test-chan (async/chan 1)
           chs [(declare-events-exchange conn "events" "topic" {})
-               (incoming-events-channel conn "test-in" {} "test-event" ch-in 1000)
+               (incoming-events-channel conn "test-in" {} "events" "test-event" ch-in 1000)
                (outgoing-events-channel conn "events" "test-event" ch-out)]]
       (try
         (start-event-handler! ch-in (fn [message]

--- a/test/kehaar/wire_up_test.clj
+++ b/test/kehaar/wire_up_test.clj
@@ -22,7 +22,7 @@
         (dotimes [x 1000]
           (let [x (java.util.UUID/randomUUID)]
             (bounded>!! ch-out {:hello! :there! :uuid x} 100)
-            (is (= {:hello! :there! :uuid x} (:message (bounded<!! ch-in 100))))))
+            (is (= {:hello! :there! :uuid x} (bounded<!! ch-in 100)))))
         (finally
           (async/close! ch-in)
           (async/close! ch-out)
@@ -45,7 +45,7 @@
           (doseq [message messages]
             (bounded>!! ch-out message 100))
           (doseq [message messages]
-            (is (= message (:message (bounded<!! ch-in 100))))))
+            (is (= message (bounded<!! ch-in 100)))))
         (finally
           (async/close! ch-in)
           (async/close! ch-out)

--- a/test/kehaar/wire_up_test.clj
+++ b/test/kehaar/wire_up_test.clj
@@ -21,7 +21,7 @@
       (try
         (dotimes [x 1000]
           (let [x (java.util.UUID/randomUUID)]
-            (bounded>!! ch-out {:message {:hello! :there! :uuid x}} 100)
+            (bounded>!! ch-out {:hello! :there! :uuid x} 100)
             (is (= {:hello! :there! :uuid x} (:message (bounded<!! ch-in 100))))))
         (finally
           (async/close! ch-in)
@@ -43,7 +43,7 @@
                              :let [x (java.util.UUID/randomUUID)]]
                          {:hello! x})]
           (doseq [message messages]
-            (bounded>!! ch-out {:message message} 100))
+            (bounded>!! ch-out message 100))
           (doseq [message messages]
             (is (= message (:message (bounded<!! ch-in 100))))))
         (finally
@@ -64,7 +64,7 @@
       (try
         (start-event-handler! ch-in (fn [message]
                                       (bounded>!! test-chan :hello 100)))
-        (bounded>!! ch-out {:message :hello} 100)
+        (bounded>!! ch-out :hello 100)
         (is (= :hello (bounded<!! test-chan 100)))
         (finally
           (async/close! ch-in)

--- a/test/kehaar/wire_up_test.clj
+++ b/test/kehaar/wire_up_test.clj
@@ -1,0 +1,158 @@
+(ns kehaar.wire-up-test
+  (:require [kehaar.wire-up :refer :all]
+            [clojure.test :refer :all]
+            [clojure.core.async :as async]
+            [langohr.core :as rmq]
+            [langohr.channel :as lch]
+            [langohr.queue :as lq]
+            [langohr.basic :as lb]
+            [langohr.consumers :as lc]
+            [clojure.tools.logging :as log]
+            [kehaar.async :refer [bounded<!! bounded>!!]]))
+
+(deftest ^:rabbit-mq events-test
+  (testing "we can publish events and receive them, going through rabbit"
+    (let [conn   (rmq/connect)
+          ch-out (async/chan 1000)
+          ch-in  (async/chan 1000)
+          chs [(declare-events-exchange conn "events" "topic" {})
+               (incoming-events-channel conn "test-in" {} "test-event" ch-in 1000)
+               (outgoing-events-channel conn "events" "test-event" ch-out)]]
+      (try
+        (dotimes [x 1000]
+          (let [x (java.util.UUID/randomUUID)]
+            (bounded>!! ch-out {:message {:hello! :there! :uuid x}} 100)
+            (is (= {:hello! :there! :uuid x} (:message (bounded<!! ch-in 100))))))
+        (finally
+          (async/close! ch-in)
+          (async/close! ch-out)
+          (doseq [ch chs]
+            (rmq/close ch))
+          (rmq/close conn)))))
+
+  (testing "we can publish a bunch of events and then receive them
+  later, going through rabbit"
+    (let [conn   (rmq/connect)
+          ch-out (async/chan 1000)
+          ch-in  (async/chan 1000)
+          chs [(declare-events-exchange conn "events" "topic" {})
+               (incoming-events-channel conn "test-in" {} "test-event" ch-in 1000)
+               (outgoing-events-channel conn "events" "test-event" ch-out)]]
+      (try
+        (let [messages (for [x (range 1000)
+                             :let [x (java.util.UUID/randomUUID)]]
+                         {:hello! x})]
+          (doseq [message messages]
+            (bounded>!! ch-out {:message message} 100))
+          (doseq [message messages]
+            (is (= message (:message (bounded<!! ch-in 100))))))
+        (finally
+          (async/close! ch-in)
+          (async/close! ch-out)
+          (doseq [ch chs]
+            (rmq/close ch))
+          (rmq/close conn)))))
+
+  (testing "we can set up a handler function on incoming events"
+    (let [conn   (rmq/connect)
+          ch-out (async/chan 1000)
+          ch-in  (async/chan 1000)
+          test-chan (async/chan 1)
+          chs [(declare-events-exchange conn "events" "topic" {})
+               (incoming-events-channel conn "test-in" {} "test-event" ch-in 1000)
+               (outgoing-events-channel conn "events" "test-event" ch-out)]]
+      (try
+        (start-event-handler! ch-in (fn [message]
+                                      (bounded>!! test-chan :hello 100)))
+        (bounded>!! ch-out {:message :hello} 100)
+        (is (= :hello (bounded<!! test-chan 100)))
+        (finally
+          (async/close! ch-in)
+          (async/close! ch-out)
+          (doseq [ch chs]
+            (rmq/close ch))
+          (rmq/close conn))))))
+
+(deftest event-handler-test
+  (testing "our event handler fires"
+    (let [in (async/chan)
+          out (async/chan)]
+      (try
+        (start-event-handler! in (fn [_] (async/put! out 1)))
+        (async/put! in 100)
+        (is (= 1 (bounded<!! out 100)))
+        (finally
+          (async/close! in)
+          (async/close! out))))))
+
+(deftest simple-service-test
+  (testing "we can return a value"
+    (let [in (async/chan 1)
+          out (async/chan 1)
+          service-fn (fn [{:keys [n]}]
+                       (* 10 n))
+          metadata {:dude 100}]
+      (try
+        (start-responder! in out service-fn)
+        (bounded>!! in {:message {:n 20}
+                        :metadata metadata} 100)
+        (is (= {:message 200
+                :metadata metadata} (bounded<!! out 100)))
+        (finally (async/close! out)
+                 (async/close! in)))))
+
+  (testing "we can return nil"
+    (let [in (async/chan 1)
+          out (async/chan 1)
+          service-fn (fn [_]
+                       nil)
+          metadata {:dude 100}]
+      (try
+        (start-responder! in out service-fn)
+        (bounded>!! in {:message {:n 20}
+                        :metadata metadata} 100)
+        (is (nil? (:message (bounded<!! out 100))))
+        (finally (async/close! out)
+                 (async/close! in)))))
+
+  (testing "we can return a channel"
+    (let [in (async/chan 1)
+          out (async/chan 1)
+          service-fn (fn [{:keys [n]}]
+                       (async/go (* 10 n)))
+          metadata {:dude 100}]
+      (try
+        (start-responder! in out service-fn)
+        (bounded>!! in {:message {:n 20}
+                        :metadata metadata} 100)
+        (is (= {:message 200
+                :metadata metadata} (bounded<!! out 100)))
+        (finally (async/close! out)
+                 (async/close! in))))))
+
+(deftest ^:rabbit-mq service-test
+  (testing "create an incoming service and an outgoing services that
+  calls it, roundtripping through rabbit."
+    (let [conn   (rmq/connect)
+          ch-ext (async/chan 1000)
+          ch-in  (async/chan 1000)
+          ch-out  (async/chan 1000)
+          test-chan (async/chan 1)
+          chs [(incoming-service conn "this.is.my.service" {}
+                                 ch-in ch-out)
+               (external-service conn "this.is.my.service" ch-ext)]
+          f (kehaar.core/async->fn ch-ext)]
+      (try
+        (start-responder! ch-in ch-out
+                          (fn [message]
+                            (log/debug "I am here!")
+                            {:answer (* 100 (:n message))}))
+        (is (= {:answer 3400} (bounded<!! (f {:n 34}) 1000)))
+        (finally
+          (async/close! ch-in)
+          (async/close! ch-ext)
+          (async/close! ch-out)
+          (doseq [ch chs]
+            (rmq/close ch))
+          (rmq/close conn))))))
+


### PR DESCRIPTION
This is a major change. It renames and reworks the existing
functionality.

The main motivation for this was to make kehaar more robust when faced
with errors. EDN parse errors would cause the entire handler to
crash. And kehaar would read as many messages as it could at a time,
potentially overloading the server with no recourse for backpressure.

This rewrite solves those two problems while renaming and reworking the
abstractions. The main difference is that the functions which pump
messages to and from rabbit <=> core.async now pass the payload *and*
metadata. This simplified the code a lot since we often need the
metadata.

Event handlers and service responders now run in their own threads. call
`start-event-handler!` and `start-responder!` in server initialization
to start those. The return value of event handlers is ignored, but
responders can return any value or a channel which will contain the
value. This lets things remain asynchronous.
