### PR TITLE
default to more typical queue options in wire-up/external-service

### DIFF
--- a/src/kehaar/wire_up.clj
+++ b/src/kehaar/wire_up.clj
@@ -75,7 +75,9 @@
   that channel."
   ([connection queue-name channel]
    (external-service connection ""
-                     queue-name {:exclusive false :auto-delete true}
+                     queue-name {:exclusive false
+                                 :durable true 
+                                 :auto-delete false}
                      1000 channel))
   ([connection exchange queue-name queue-options timeout channel]
    (let [ch (langohr.channel/open connection)]

--- a/test/kehaar/wire_up_test.clj
+++ b/test/kehaar/wire_up_test.clj
@@ -141,7 +141,9 @@
           chs [(incoming-service conn "this.is.my.service"
                                  {:exclusive false :durable false :auto-delete true}
                                  ch-in ch-out)
-               (external-service conn "this.is.my.service" ch-ext)]
+               (external-service conn "" "this.is.my.service"
+                                 {:exclusive false :durable false :auto-delete true}
+                                 1000 ch-ext)]
           f (async->fn ch-ext)]
       (try
         (start-responder! ch-in ch-out

--- a/test/kehaar/wire_up_test.clj
+++ b/test/kehaar/wire_up_test.clj
@@ -138,7 +138,8 @@
           ch-in  (async/chan 1000)
           ch-out  (async/chan 1000)
           test-chan (async/chan 1)
-          chs [(incoming-service conn "this.is.my.service" {}
+          chs [(incoming-service conn "this.is.my.service"
+                                 {:exclusive false :durable true :auto-delete false}
                                  ch-in ch-out)
                (external-service conn "this.is.my.service" ch-ext)]
           f (async->fn ch-ext)]

--- a/test/kehaar/wire_up_test.clj
+++ b/test/kehaar/wire_up_test.clj
@@ -139,7 +139,7 @@
           ch-out  (async/chan 1000)
           test-chan (async/chan 1)
           chs [(incoming-service conn "this.is.my.service"
-                                 {:exclusive false :durable true :auto-delete false}
+                                 {:exclusive false :durable false :auto-delete true}
                                  ch-in ch-out)
                (external-service conn "this.is.my.service" ch-ext)]
           f (async->fn ch-ext)]


### PR DESCRIPTION
These are the options we use everywhere, and seem to make more sense to me even in the context of this open-source, general-purpose library. But if others feel differently, there are other ways to improve upon this. Currently the workaround is to use the higher-arity version everywhere. But as it is, I'm not sure the lower-arity version would be useful to anyone (or at least, it isn't to us).