### PR TITLE
add responder test helper

### DIFF
--- a/src/kehaar/test_helpers.clj
+++ b/src/kehaar/test_helpers.clj
@@ -5,7 +5,7 @@
   ([in-channel out-channel] (responder-test in-channel out-channel 10000))
   ([in-channel out-channel timeout]
    (fn [message]
-     (let [request-result (async/alt!! [in-channel {:message message}] ::sent
+     (let [request-result (async/alt!! [[in-channel {:message message}]] ::sent
                                        (async/timeout timeout) ::timeout)]
        (case request-result
          ::sent (:message (async/alt!! out-channel ([v] v)

--- a/src/kehaar/test_helpers.clj
+++ b/src/kehaar/test_helpers.clj
@@ -7,7 +7,7 @@
    (fn [message]
      (let [request-result (async/alt!! [in-channel {:message message}] ::sent
                                        (async/timeout timeout) ::timeout)]
-       (cond request-result
-             ::sent (:message (async/alt!! out-channel ([v] v)
-                                           (async/timeout timeout) ::timeout))
-             ::timeout ::timeout)))))
+       (case request-result
+         ::sent (:message (async/alt!! out-channel ([v] v)
+                                       (async/timeout timeout) ::timeout))
+         ::timeout ::timeout)))))

--- a/src/kehaar/test_helpers.clj
+++ b/src/kehaar/test_helpers.clj
@@ -1,0 +1,13 @@
+(ns kehaar.test-helpers
+  (:require [clojure.core.async :as async]))
+
+(defn responder-test
+  ([in-channel out-channel] (responder-test in-channel out-channel 10000))
+  ([in-channel out-channel timeout]
+   (fn [message]
+     (let [request-result (async/alt!! [in-channel {:message message}] ::sent
+                                       (async/timeout timeout) ::timeout)]
+       (cond request-result
+             ::sent (:message (async/alt!! out-channel ([v] v)
+                                           (async/timeout timeout) ::timeout))
+             ::timeout ::timeout)))))


### PR DESCRIPTION
It's hard to test responders with the same kinds of messages you'd send over Rabbit, and this pulls in the timeout boilerplate stuff too.

I used this to test the [new kehaar-0.5.x responder in address-works](https://github.com/democracyworks/address-works/pull/51).