### PR TITLE
RabbitMQ config for tests

### DIFF
--- a/test/kehaar/rabbit_mq_test.clj
+++ b/test/kehaar/rabbit_mq_test.clj
@@ -9,18 +9,19 @@
             [langohr.consumers :as lc]
             [clojure.tools.logging :as log]
             [kehaar.async :refer [bounded<!! bounded>!!]]
-            [kehaar.rabbitmq :refer [connect-with-retries]]))
+            [kehaar.rabbitmq :refer [connect-with-retries]]
+            [kehaar.test-config :refer [rmq-config]]))
 
 (deftest ^:rabbit-mq connect-with-retries-test
   (testing "connects to running broker and returns connection"
-    (is (= (class (connect-with-retries {}))
+    (is (= (class (connect-with-retries rmq-config))
            com.novemberain.langohr.Connection)))
   (testing "throws exception when broker unavailable"
     (is (thrown? java.net.ConnectException
                  (connect-with-retries {:host "localhost" :port 65535} 1)))))
 
 (deftest ^:rabbit-mq async=>rabbit-rabbit=>async-test
-  (let [conn (rmq/connect)
+  (let [conn (rmq/connect rmq-config)
         ch (lch/open conn)
         rabbit-queue (lq/declare-server-named ch {:exclusive true})
         chan (async/chan)
@@ -36,7 +37,7 @@
     (rmq/close conn)))
 
 (deftest ^:rabbit-mq async=>rabbit-with-reply-to-rabbit=>async-test
-  (let [conn (rmq/connect)
+  (let [conn (rmq/connect rmq-config)
         ch (lch/open conn)
         rabbit-queue (lq/declare-server-named ch {:exclusive true})
         chan (async/chan)

--- a/test/kehaar/test_config.clj
+++ b/test/kehaar/test_config.clj
@@ -1,0 +1,5 @@
+(ns kehaar.test-config)
+
+(def rmq-config
+  {:host (or (System/getenv "RABBITMQ_HOST") "localhost")
+   :port (Integer. (or (System/getenv "RABBITMQ_PORT") 5672))})

--- a/test/kehaar/wire_up_test.clj
+++ b/test/kehaar/wire_up_test.clj
@@ -16,9 +16,9 @@
     (let [conn   (rmq/connect rmq-config)
           ch-out (async/chan 1000)
           ch-in  (async/chan 1000)
-          chs [(declare-events-exchange conn "events" "topic" {})
-               (incoming-events-channel conn "test-in" {} "events" "test-event" ch-in 1000)
-               (outgoing-events-channel conn "events" "test-event" ch-out)]]
+          chs [(declare-events-exchange conn "test-events" "topic" {})
+               (incoming-events-channel conn "test-in" {} "test-events" "test-event" ch-in 1000)
+               (outgoing-events-channel conn "test-events" "test-event" ch-out)]]
       (try
         (dotimes [x 1000]
           (let [x (java.util.UUID/randomUUID)]
@@ -36,9 +36,9 @@
     (let [conn   (rmq/connect rmq-config)
           ch-out (async/chan 1000)
           ch-in  (async/chan 1000)
-          chs [(declare-events-exchange conn "events" "topic" {})
-               (incoming-events-channel conn "test-in" {} "events" "test-event" ch-in 1000)
-               (outgoing-events-channel conn "events" "test-event" ch-out)]]
+          chs [(declare-events-exchange conn "test-events" "topic" {})
+               (incoming-events-channel conn "test-in" {} "test-events" "test-event" ch-in 1000)
+               (outgoing-events-channel conn "test-events" "test-event" ch-out)]]
       (try
         (let [messages (for [x (range 1000)
                              :let [x (java.util.UUID/randomUUID)]]
@@ -59,9 +59,9 @@
           ch-out (async/chan 1000)
           ch-in  (async/chan 1000)
           test-chan (async/chan 1)
-          chs [(declare-events-exchange conn "events" "topic" {})
-               (incoming-events-channel conn "test-in" {} "events" "test-event" ch-in 1000)
-               (outgoing-events-channel conn "events" "test-event" ch-out)]]
+          chs [(declare-events-exchange conn "test-events" "topic" {})
+               (incoming-events-channel conn "test-in" {} "test-events" "test-event" ch-in 1000)
+               (outgoing-events-channel conn "test-events" "test-event" ch-out)]]
       (try
         (start-event-handler! ch-in (fn [message]
                                       (bounded>!! test-chan :hello 100)))

--- a/test/kehaar/wire_up_test.clj
+++ b/test/kehaar/wire_up_test.clj
@@ -8,11 +8,12 @@
             [langohr.basic :as lb]
             [langohr.consumers :as lc]
             [clojure.tools.logging :as log]
-            [kehaar.async :refer [bounded<!! bounded>!!]]))
+            [kehaar.async :refer [bounded<!! bounded>!!]]
+            [kehaar.test-config :refer [rmq-config]]))
 
 (deftest ^:rabbit-mq events-test
   (testing "we can publish events and receive them, going through rabbit"
-    (let [conn   (rmq/connect)
+    (let [conn   (rmq/connect rmq-config)
           ch-out (async/chan 1000)
           ch-in  (async/chan 1000)
           chs [(declare-events-exchange conn "events" "topic" {})
@@ -32,7 +33,7 @@
 
   (testing "we can publish a bunch of events and then receive them
   later, going through rabbit"
-    (let [conn   (rmq/connect)
+    (let [conn   (rmq/connect rmq-config)
           ch-out (async/chan 1000)
           ch-in  (async/chan 1000)
           chs [(declare-events-exchange conn "events" "topic" {})
@@ -54,7 +55,7 @@
           (rmq/close conn)))))
 
   (testing "we can set up a handler function on incoming events"
-    (let [conn   (rmq/connect)
+    (let [conn   (rmq/connect rmq-config)
           ch-out (async/chan 1000)
           ch-in  (async/chan 1000)
           test-chan (async/chan 1)
@@ -133,7 +134,7 @@
 (deftest ^:rabbit-mq service-test
   (testing "create an incoming service and an outgoing services that
   calls it, roundtripping through rabbit."
-    (let [conn   (rmq/connect)
+    (let [conn   (rmq/connect rmq-config)
           ch-ext (async/chan 1000)
           ch-in  (async/chan 1000)
           ch-out  (async/chan 1000)
@@ -168,7 +169,7 @@
       (is (= [response-channel message] (async/<!! c)))))
   (testing "response is nil when no response to service past timeout"
     (let [timeout   2000
-          conn      (rmq/connect)
+          conn      (rmq/connect rmq-config)
           ch-async  (async/chan 1000)
           ch-rabbit (external-service
                      conn "" "this.is.my.service"


### PR DESCRIPTION
Adds a `kehaar.test-config` ns for either using environment vars or default localhost/5672 config; re-named "events" exchange to "test-events" to avoid collision (when using krakenstein RabbitMQ as your test instance, in my case).

Understand that the latter may be more appropriate as a second PR, assuming this is acceptable at all--happy to do that or whatever is needed.