### PR TITLE
Streaming

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,18 @@
 # Change Log
 
+## Changes between Kehaar 0.5.0 and HEAD
+
+### Streaming responders
+
+Added `start-streaming-responder!` and `streaming-external-service` to
+the `kehaar.wire-up` namespace for starting and consuming streaming
+responses. Those functions are used for streaming responders in place
+of `start-responder!` and `external-service` respectively.
+
+A streaming responder function merely needs to return a sequence
+(lazy, if you like) and the values from that sequence will be sent
+across RabbitMQ to a core.async channel on the consumer's side.
+
 ## Changes between Kehaar 0.4.0 and 0.5.0
 
 ### kehaar.rabbitmq/connect-with-retries

--- a/example/project.clj
+++ b/example/project.clj
@@ -4,5 +4,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.7.0"]
-                 [democracyworks/kehaar "0.5.0"]]
-  :main kehaar-example.core)
+                 [democracyworks/kehaar "0.5.1-SNAPSHOT"]]
+  :main kehaar-example.core
+  :aliases {"streaming-producer" ["run" "-m" "kehaar-example.streaming.producer"]
+            "streaming-consumer" ["run" "-m" "kehaar-example.streaming.consumer"]})

--- a/example/src/kehaar_example/core.clj
+++ b/example/src/kehaar_example/core.clj
@@ -87,7 +87,10 @@
         ;; `outgoing-fib-requests` core.async channel. Uses the
         ;; "calculate-fib" queue the service set up.
         outgoing-service-ch (wire-up/external-service conn
+                                                      ""
                                                       "calculate-fib"
+                                                      {:auto-delete true}
+                                                      1000
                                                       outgoing-fib-requests)]
     [events-ch
      event-listener-ch
@@ -123,4 +126,8 @@
     (log/info "Requesting fib:" n)
     (let [fib-response (get-fib n)]
       (async/go
-        (log/info "Got fib:" n "Result:" (async/<! fib-response))))))
+        (log/info "Got fib:" n "Result:" (async/<! fib-response)))))
+
+  ;; Give it a few seconds then exit
+  (Thread/sleep 5000)
+  (System/exit 0))

--- a/example/src/kehaar_example/streaming/consumer.clj
+++ b/example/src/kehaar_example/streaming/consumer.clj
@@ -1,0 +1,47 @@
+(ns kehaar-example.streaming.consumer
+  (:require [kehaar.rabbitmq :as kehaar-rabbit]
+            [kehaar.wire-up :as wire-up]
+            [clojure.core.async :as async]
+            [clojure.tools.logging :as log]))
+
+(def outgoing-countdown-requests (async/chan 100))
+(def get-countdown (wire-up/async->fn outgoing-countdown-requests))
+
+(defn -main [& args]
+  (log/info "Consumer starting up...")
+  (let [connection (kehaar-rabbit/connect-with-retries)
+        outgoing-service-ch (wire-up/streaming-external-service
+                             connection
+                             ""
+                             "countdown"
+                             {}
+                             5000
+                             outgoing-countdown-requests)]
+    (log/info "Consumer making a request!")
+    (doseq [n [10 10 3 3 10]]
+      (let [return-ch (get-countdown {:num n})]
+        (loop []
+          (when-let [v (async/<!! return-ch)]
+            (log/info "Got" v)
+            (recur)))))
+    (log/info "Consumer making a request!")
+    (let [return-ch (get-countdown {:num 4 :delay 3000})
+          v (async/<!! return-ch)]
+      (log/info "Got" v)
+      (async/close! return-ch)
+      (log/info "Closed return channel"))
+    (log/info "Consumer making a request!")
+    (let [return-ch (get-countdown {:num 100 :delay 200})]
+      (dotimes [n 10]
+        (when-let [v (async/<!! return-ch)]
+          (log/info "Got" v)))
+      (async/close! return-ch)
+      (log/info "Closed return channel"))
+    (doseq [n [2 2 2 2 2]]
+      (let [return-ch (get-countdown {:num n})]
+        (loop []
+          (when-let [v (async/<!! return-ch)]
+            (log/info "Got" v)
+            (recur)))))
+    (Thread/sleep 10000)
+    (System/exit 0)))

--- a/example/src/kehaar_example/streaming/producer.clj
+++ b/example/src/kehaar_example/streaming/producer.clj
@@ -1,0 +1,29 @@
+(ns kehaar-example.streaming.producer
+  (:require [kehaar.rabbitmq :as kehaar-rabbit]
+            [kehaar.wire-up :as wire-up]
+            [clojure.core.async :as async]
+            [clojure.tools.logging :as log]))
+
+(def in-ch (async/chan))
+(def out-ch (async/chan))
+
+(defn countdown [{:keys [num delay]}]
+  (log/info "Counting down from" num)
+  (when (>= num 0)
+    (lazy-seq
+     (Thread/sleep (or delay 0))
+     (cons num (countdown {:num (dec num)
+                           :delay delay})))))
+
+(defn -main [& args]
+  (log/info "Producer starting up...")
+  (let [connection (kehaar-rabbit/connect-with-retries)]
+
+    (wire-up/incoming-service
+     connection "countdown" {} in-ch out-ch)
+
+    (wire-up/start-streaming-responder!
+     connection in-ch out-ch countdown 5))
+  (log/info "Producer ready!")
+  (loop []
+    (recur)))

--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.7.0"]
-                 [org.clojure/core.async "0.1.346.0-17112a-alpha"]
+                 [org.clojure/core.async "0.2.385"]
                  [com.novemberain/langohr "3.2.0"]
                  [org.clojure/tools.logging "0.3.1"]]
   :test-selectors {:default (complement :rabbit-mq)

--- a/src/kehaar/async.clj
+++ b/src/kehaar/async.clj
@@ -2,11 +2,10 @@
   (:require [clojure.core.async :as async]))
 
 (defn bounded>!!
-  "Like async/>!, but with a timeout."
+  "Like async/>!!, but with a timeout."
   [channel message timeout]
-  (async/alt!!
-    [[channel message]] true
-    (async/timeout timeout) false))
+  (async/alt!! [[channel message]] ([result] result)
+               (async/timeout timeout) ::timeout))
 
 (defn bounded<!! [channel timeout]
   (async/alt!!

--- a/src/kehaar/core.clj
+++ b/src/kehaar/core.clj
@@ -116,7 +116,8 @@
           (log/warn "Kehaar: thread handler is closed.")
           (do
             (try
-              (f ch-message)
+              (async/thread
+                (f ch-message))
               (catch Throwable t
                 (log/error t "Kehaar: caught exception in thread-handler")))
             (recur)))))))

--- a/src/kehaar/core.clj
+++ b/src/kehaar/core.clj
@@ -171,6 +171,12 @@
                                 :metadata metadata})))))
 
 (defn streaming-responder-fn
+  "Create a function that takes map of message and metadata, calls `f`
+  on message, and redirects the return to `out-channel`. If the size
+  of the response is going to be larger than `threshold`, they are
+  placed on a bespoke queue and the queue's name is placed on the
+  `out-channel` instead of the results. Sends a `::stop` message when
+  the response sequence is exhausted."
   [connection out-channel f threshold]
   (fn [{:keys [message metadata]}]
     (let [return (f message)

--- a/src/kehaar/wire_up.clj
+++ b/src/kehaar/wire_up.clj
@@ -56,6 +56,12 @@
    in-channel
    (kehaar.core/responder-fn out-channel f)))
 
+(defn start-streaming-responder!
+  [connection in-channel out-channel f threshold]
+  (kehaar.core/thread-handler
+   in-channel
+   (kehaar.core/streaming-responder-fn connection out-channel f threshold)))
+
 (defn incoming-service
   "Wire up an incoming channel and an outgoing channel. Later, you
   should call `start-responder!` with the same channels and a handler
@@ -76,7 +82,7 @@
   ([connection queue-name channel]
    (external-service connection ""
                      queue-name {:exclusive false
-                                 :durable true 
+                                 :durable true
                                  :auto-delete false}
                      1000 channel))
   ([connection exchange queue-name queue-options timeout channel]
@@ -91,7 +97,8 @@
            >request-channel (async/chan 1000)]
 
        ;; start listening for responses
-       (kehaar.core/rabbit=>async ch response-queue <response-channel {} 1000)
+       (kehaar.core/rabbit=>async ch response-queue <response-channel
+                                  {:exclusive true} 1000)
        (kehaar.core/go-handler
         [{:keys [message metadata]} <response-channel]
         (let [correlation-id (:correlation-id metadata)]
@@ -100,18 +107,108 @@
             (swap! pending-calls dissoc correlation-id))))
 
        ;; bookkeeping for sending the requests
-       (kehaar.core/async=>rabbit >request-channel ch "" queue-name)
+       (kehaar.core/async=>rabbit >request-channel ch exchange queue-name)
        (kehaar.core/go-handler
         [[return-channel message] channel]
         (let [correlation-id (str (java.util.UUID/randomUUID))]
           (swap! pending-calls assoc correlation-id return-channel)
           (async/>! >request-channel {:message message
                                       :metadata {:correlation-id correlation-id
-                                                 :reply-to response-queue}})
+                                                 :reply-to response-queue
+                                                 :mandatory true}})
           (async/go
             (async/<! (async/timeout timeout))
             (when-let [chan (get @pending-calls correlation-id)]
               (async/close! chan)
+              (swap! pending-calls dissoc correlation-id))))))
+     ch)))
+
+(defn streaming-external-service
+  "Wires up a core.async channel to a RabbitMQ queue that provides
+  responses. Use `async->fn` to create a function that puts to
+  that channel."
+  ([connection queue-name channel]
+   (streaming-external-service connection ""
+                               queue-name {:exclusive false
+                                           :durable true
+                                           :auto-delete false}
+                               1000 channel))
+  ([connection exchange queue-name queue-options timeout channel]
+   (let [ch (langohr.channel/open connection)]
+     (langohr.queue/declare ch queue-name queue-options)
+     (let [response-queue (langohr.queue/declare-server-named
+                           ch
+                           {:exclusive true
+                            :auto-delete true})
+           pending-calls (atom {})
+           <response-channel (async/chan)
+           >request-channel (async/chan 1000)]
+
+       ;; start listening for responses
+       (kehaar.core/rabbit=>async ch response-queue <response-channel
+                                  {:exclusive true} 1000)
+       (kehaar.core/go-handler
+        [{:keys [message metadata]} <response-channel]
+        (let [correlation-id (:correlation-id metadata)]
+          (cond
+            (= :kehaar.core/stop message)
+            (when-let [return-channel (get-in @pending-calls [correlation-id :return-channel])]
+              (async/close! return-channel)
+              (swap! pending-calls dissoc correlation-id))
+
+            (and (map? message)
+                 (:kehaar.core/inline message))
+            nil                         ; do nothing
+
+            (and (map? message)
+                 (:kehaar.core/response-queue message))
+            (if-let [return-channel (get-in @pending-calls [correlation-id :return-channel])]
+              (let [message-channel (async/chan 1 (map :message))
+                    response-queue (:kehaar.core/response-queue message)]
+                (kehaar.core/rabbit=>async
+                 ch
+                 response-queue
+                 message-channel
+                 {:exclusive true}
+                 100
+                 true)
+                (loop []
+                  (let [msg (async/<! message-channel)]
+                    (when (get-in @pending-calls [correlation-id :timeout])
+                      (swap! pending-calls update correlation-id dissoc :timeout))
+                    (if (nil? msg)
+                      (async/close! return-channel)
+                      (if (async/>! return-channel msg)
+                        (recur)
+                        (async/close! message-channel))))))
+              (do
+                (log/info (format "Deleting queue %s" (:kehaar.core/response-queue message)))
+                (langohr.queue/delete ch (:kehaar.core/response-queue message))))
+
+            :else
+            (when-let [return-channel (get-in @pending-calls [correlation-id :return-channel])]
+              (when (get-in @pending-calls [correlation-id :timeout])
+                (swap! pending-calls update correlation-id dissoc :timeout))
+              (async/>! return-channel message)))))
+
+       ;; bookkeeping for sending the requests
+       (kehaar.core/async=>rabbit >request-channel ch exchange queue-name)
+       (kehaar.core/go-handler
+        [[return-channel message] channel]
+        (let [correlation-id (str (java.util.UUID/randomUUID))
+              timeout-ch (async/timeout timeout)]
+          (swap! pending-calls assoc correlation-id {:return-channel return-channel
+                                                     :timeout timeout-ch})
+          (async/>! >request-channel {:message message
+                                      :metadata {:correlation-id correlation-id
+                                                 :reply-to response-queue
+                                                 :mandatory true}})
+
+          (async/go
+            (async/<! timeout-ch)
+            (when (get-in @pending-calls [correlation-id :timeout])
+              (log/info "Streaming request timed out")
+              (async/close! (get-in @pending-calls [correlation-id :return-channel]))
               (swap! pending-calls dissoc correlation-id))))))
      ch)))
 

--- a/src/kehaar/wire_up.clj
+++ b/src/kehaar/wire_up.clj
@@ -57,6 +57,9 @@
    (kehaar.core/responder-fn out-channel f)))
 
 (defn start-streaming-responder!
+  "Start a new thread that listens on in-channel and responds on
+  out-channel. threshold is the number of elements beyond which they
+  should be placed on a bespoke RabbitMQ for the consumer."
   [connection in-channel out-channel f threshold]
   (kehaar.core/thread-handler
    in-channel

--- a/test/kehaar/core_test.clj
+++ b/test/kehaar/core_test.clj
@@ -68,3 +68,16 @@
       (is (= {:message 100
               :metadata :dude!}
              (bounded<!! c 100))))))
+
+(deftest thread-handler-test
+  (testing "Carries on in the face of exceptions thrown by f"
+    (let [channel (async/chan)
+          results-channel (async/chan 3)
+          f (fn [n]
+              (async/>!! results-channel (/ 1 n)))]
+      (thread-handler channel f)
+      (async/>!! channel 2)
+      (async/>!! channel 0)
+      (async/>!! channel 3)
+      (is (= (/ 1 2) (async/<!! results-channel)))
+      (is (= (/ 1 3) (async/<!! results-channel))))))


### PR DESCRIPTION
# Streaming!

A streaming responder is simply a function that returns a sequence. A streaming consumer is just one that expects any number of values on its response channel.

To this end, there are streaming versions of `wire-up/start-responder!` and `wire-up/external-service`, called `start-streaming-responder!` and `streaming-external-service` respectively.

`start-streaming-responder!` takes a couple of extra arguments. The RabbitMQ connection at the front (so that bespoke response queues can be made as needed) and a threshold at the end. The threshold determines at what size the response values should be placed on a bespoke queue instead of the main response queue.

`streaming-external-service` behaves the same as `external-service`.

See the example streaming project for more.