### PR TITLE
Configurable number of threads to handle messages

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,24 @@
 # Change Log
 
+## Changes between Kehaar 0.6.0 and HEAD
+
+### Configurable number of threads to handle messages with
+
+`start-responder!`, `start-streaming-responder!`, and
+`start-event-handler!` can now take an extra argument: a number of
+threads to use to pull messages from their input channels. The threads
+will be created and be waiting on new messages immediately. The
+default number of threads is 10.
+
+### Sleeping on nack
+
+When `rabbit=>async` nacks a message, it sleeps for one second before
+attempting to take another message. Eventually this will be
+configurable.
+
+Together with the limited number of threads for message handlers, this
+better allows for backpressure from core.async to RabbitMQ.
+
 ## Changes between Kehaar 0.5.0 and 0.6.0
 
 ### Streaming responders

--- a/README.md
+++ b/README.md
@@ -137,8 +137,9 @@ argument, like `handler-function`, but should always return a sequence
 (lazy, if you like). Each value in the sequence will be returned to
 the client in order.
 
-You can call `wire-up/start-responder!` multiple times to start
-different threads running the same handler.
+`wire-up/start-responder!` and `wire-up/start-streaming-responder!`
+all take an extra optional argument for the number of threads to take
+and handle messages on. The default is 10.
 
 Incoming messages are nacked if the thread is taking too long to
 process the messages. This allows different instances of the service
@@ -181,7 +182,8 @@ a core.async channel that will include the result (also must be
 edenizable). That second option lets you maintain asynchrony because
 other services using kehaar are doing the same.
 
-Each call to `wire-up/start-event-handler!` creates a new thread.
+`wire-up/start-event-handler!` takes an optional argument for the
+number of threads to take and handle messages on. The default is 10.
 
 Incoming messages are nacked if the thread is taking too long to
 process the messages. This allows different instances of the service

--- a/example/project.clj
+++ b/example/project.clj
@@ -4,7 +4,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.7.0"]
-                 [democracyworks/kehaar "0.5.1-SNAPSHOT"]]
+                 [democracyworks/kehaar "0.6.1-SNAPSHOT"]]
   :main kehaar-example.core
   :aliases {"streaming-producer" ["run" "-m" "kehaar-example.streaming.producer"]
             "streaming-consumer" ["run" "-m" "kehaar-example.streaming.consumer"]})

--- a/example/src/kehaar_example/streaming/producer.clj
+++ b/example/src/kehaar_example/streaming/producer.clj
@@ -24,6 +24,4 @@
 
     (wire-up/start-streaming-responder!
      connection in-ch out-ch countdown 5))
-  (log/info "Producer ready!")
-  (loop []
-    (recur)))
+  (log/info "Producer ready!"))

--- a/src/kehaar/core.clj
+++ b/src/kehaar/core.clj
@@ -61,7 +61,9 @@
 (defn- ack-nack-or-cancel [channel queue close-channel? [op delivery-tag requeue :as ret]]
   (case op
     :ack    (lb/ack  channel delivery-tag)
-    :nack   (lb/nack channel delivery-tag false requeue)
+    :nack   (do
+              (lb/nack channel delivery-tag false requeue)
+              (Thread/sleep 1000))
     :cancel (when close-channel?
               (try (lq/delete channel queue)
                    (catch Exception _))) ; typically this fails when it's already gone
@@ -138,19 +140,19 @@
                 (pr-str metadata))))))
 
 (defn thread-handler
-  [channel f]
-  (async/thread
-    (loop []
-      (let [ch-message (async/<!! channel)]
-        (if (nil? ch-message)
-          (log/warn "Kehaar: thread handler is closed.")
-          (do
-            (try
-              (async/thread
-                (f ch-message))
-              (catch Throwable t
-                (log/error t "Kehaar: caught exception in thread-handler")))
-            (recur)))))))
+  [channel f threads]
+  (dotimes [_ threads]
+    (async/thread
+      (loop []
+        (let [ch-message (async/<!! channel)]
+          (if (nil? ch-message)
+            (log/trace "Kehaar: thread handler is closed.")
+            (do
+              (try
+                (f ch-message)
+                (catch Throwable t
+                  (log/error t "Kehaar: caught exception in thread-handler")))
+              (recur))))))))
 
 (defn responder-fn
   "Create a function that takes map of message and metadata, calls `f`

--- a/src/kehaar/wire_up.clj
+++ b/src/kehaar/wire_up.clj
@@ -41,29 +41,40 @@
     (langohr.exchange/declare ch name type options)
     ch))
 
+(def default-thread-count 10)
+
 (defn start-event-handler!
-  "Start a new thread listening for messages on `channel` and passing
+  "Start new threads listening for messages on `channel` and passing
   them to `handler`. Will loop over all messages, logging errors. When
   `channel` is closed, stop looping."
-  [channel handler]
-  (kehaar.core/thread-handler channel handler))
+  ([channel handler]
+   (start-event-handler! channel handler default-thread-count))
+  ([channel handler threads]
+   (kehaar.core/thread-handler channel handler threads)))
 
 (defn start-responder!
-  "Start a new thread that listens on in-channel and responds on
+  "Start new threads that listen on in-channel and responds on
   out-channel."
-  [in-channel out-channel f]
-  (kehaar.core/thread-handler
-   in-channel
-   (kehaar.core/responder-fn out-channel f)))
+  ([in-channel out-channel f]
+   (start-responder! in-channel out-channel f default-thread-count))
+  ([in-channel out-channel f threads]
+   (kehaar.core/thread-handler
+    in-channel
+    (kehaar.core/responder-fn out-channel f)
+    threads)))
 
 (defn start-streaming-responder!
-  "Start a new thread that listens on in-channel and responds on
+  "Start new threads that listen on in-channel and respond on
   out-channel. threshold is the number of elements beyond which they
   should be placed on a bespoke RabbitMQ for the consumer."
-  [connection in-channel out-channel f threshold]
-  (kehaar.core/thread-handler
-   in-channel
-   (kehaar.core/streaming-responder-fn connection out-channel f threshold)))
+  ([connection in-channel out-channel f threshold]
+   (start-streaming-responder! connection in-channel out-channel
+                               f threshold default-thread-count))
+  ([connection in-channel out-channel f threshold threads]
+   (kehaar.core/thread-handler
+    in-channel
+    (kehaar.core/streaming-responder-fn connection out-channel f threshold)
+    threads)))
 
 (defn incoming-service
   "Wire up an incoming channel and an outgoing channel. Later, you

--- a/test/kehaar/core_test.clj
+++ b/test/kehaar/core_test.clj
@@ -75,7 +75,7 @@
           results-channel (async/chan 3)
           f (fn [n]
               (async/>!! results-channel (/ 1 n)))]
-      (thread-handler channel f)
+      (thread-handler channel f 1)
       (async/>!! channel 2)
       (async/>!! channel 0)
       (async/>!! channel 3)

--- a/test/kehaar/wire_up_test.clj
+++ b/test/kehaar/wire_up_test.clj
@@ -63,8 +63,10 @@
                (incoming-events-channel conn "test-in" {} "test-events" "test-event" ch-in 1000)
                (outgoing-events-channel conn "test-events" "test-event" ch-out)]]
       (try
-        (start-event-handler! ch-in (fn [message]
-                                      (bounded>!! test-chan :hello 100)))
+        (start-event-handler! ch-in
+                              (fn [message]
+                                (bounded>!! test-chan :hello 100))
+                              2)
         (bounded>!! ch-out :hello 100)
         (is (= :hello (bounded<!! test-chan 100)))
         (finally
@@ -79,7 +81,7 @@
     (let [in (async/chan)
           out (async/chan)]
       (try
-        (start-event-handler! in (fn [_] (async/put! out 1)))
+        (start-event-handler! in (fn [_] (async/put! out 1)) 2)
         (async/put! in 100)
         (is (= 1 (bounded<!! out 100)))
         (finally
@@ -94,7 +96,7 @@
                        (* 10 n))
           metadata {:dude 100}]
       (try
-        (start-responder! in out service-fn)
+        (start-responder! in out service-fn 1)
         (bounded>!! in {:message {:n 20}
                         :metadata metadata} 100)
         (is (= {:message 200
@@ -109,7 +111,7 @@
                        nil)
           metadata {:dude 100}]
       (try
-        (start-responder! in out service-fn)
+        (start-responder! in out service-fn 1)
         (bounded>!! in {:message {:n 20}
                         :metadata metadata} 100)
         (is (nil? (:message (bounded<!! out 100))))
@@ -123,7 +125,7 @@
                        (async/go (* 10 n)))
           metadata {:dude 100}]
       (try
-        (start-responder! in out service-fn)
+        (start-responder! in out service-fn 1)
         (bounded>!! in {:message {:n 20}
                         :metadata metadata} 100)
         (is (= {:message 200
@@ -150,7 +152,8 @@
         (start-responder! ch-in ch-out
                           (fn [message]
                             (log/debug "I am here!")
-                            {:answer (* 100 (:n message))}))
+                            {:answer (* 100 (:n message))})
+                          1)
         (is (= {:answer 3400} (bounded<!! (f {:n 34}) 1000)))
         (finally
           (async/close! ch-in)
@@ -195,7 +198,7 @@
     (let [in-ch (async/chan 1)
           out-ch (async/chan 10)
           conn (rmq/connect rmq-config)]
-      (start-streaming-responder! conn in-ch out-ch range 10)
+      (start-streaming-responder! conn in-ch out-ch range 10 1)
       (async/>!! in-ch {:message 4})
       (testing "sends a message saying the results will be inline"
         (is (get-in (async/<!! out-ch) [:message :kehaar.core/inline])))
@@ -208,7 +211,7 @@
     (let [in-ch (async/chan 1)
           out-ch (async/chan 10)
           conn (rmq/connect rmq-config)]
-      (start-streaming-responder! conn in-ch out-ch range 10)
+      (start-streaming-responder! conn in-ch out-ch range 10 1)
       (async/>!! in-ch {:message 100})
       (testing "sends a message saying the results will be on a new queue"
         (let [initial-response (async/<!! out-ch)


### PR DESCRIPTION
Instead of a single thread that spawns new threads for every message it receives, the message handler functions (`start-responder!`, `start-streaming-responder!`, and `start-event-handler!`) now spawn a fixed number of threads to handle messages.

Additionally, whenever `rabbit=>async` is unable to place a message from rabbit onto a core.async channel, after it nacks, it sleeps for a second before trying again. This will be configurable and fancy at a later date.