### PR TITLE
Set prefetch limits

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,39 @@
 # Change Log
 
+## Changes between Kehaar 0.7.0 and 0.7.1
+
+### Fire and forget
+
+Added `external-service-fire-and-forget` and
+`async->fire-and-forget-fn`, used much like their counterparts without
+"fire-and-forget" in their names to send messages to an external
+service but without waiting for a response.
+
+Added an optional argument to `incoming-service` called
+`ignore-no-reply-to`, which causes it to no longer log warnings when a
+message comes without the `:reply-to` metadata set. Good for
+decreasing the noise in a service you expect to be used by the "fire
+and forget" functions above.
+
+## Changes between Kehaar 0.6.0 and 0.7.0
+
+### Configurable number of threads to handle messages with
+
+`start-responder!`, `start-streaming-responder!`, and
+`start-event-handler!` can now take an extra argument: a number of
+threads to use to pull messages from their input channels. The threads
+will be created and be waiting on new messages immediately. The
+default number of threads is 10.
+
+### Sleeping on nack
+
+When `rabbit=>async` nacks a message, it sleeps for one second before
+attempting to take another message. Eventually this will be
+configurable.
+
+Together with the limited number of threads for message handlers, this
+better allows for backpressure from core.async to RabbitMQ.
+
 ## Changes between Kehaar 0.5.0 and 0.6.0
 
 ### Streaming responders

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A Clojure library designed to pass messages between RabbitMQ and core.async.
 
 ## Usage
 
-Add `[democracyworks/kehaar "0.6.0"]` to your dependencies.
+Add `[democracyworks/kehaar "0.7.0"]` to your dependencies.
 
 There are two ways to use Kehaar. Functions in `kehaar.core` are a
 low-level interface to connect up Rabbit and core.async. Functions in
@@ -60,6 +60,15 @@ that will eventually contain the result. If you're chaining up
 services, this channel can be returned from a handler as well, letting
 you chain async calls. The returned function takes a single argument,
 which must be some edenizable value (including `nil`).
+
+Some notes:
+
+There is also `wire-up/external-service-fire-and-forget` and
+`wire-up/async->fire-and-forget-fn` which are for services where you
+do not wish to wait for an answer. Instead of returning a core.async
+channel for a response, functions created with
+`wire-up/async->fire-and-forget-fn` will simply return `true` when
+they have successfully placed the message on the outgoing channel.
 
 * You want to make a query-response service. Send requests to
   in-channel and get responses on out-channel (core.async channels).
@@ -137,8 +146,9 @@ argument, like `handler-function`, but should always return a sequence
 (lazy, if you like). Each value in the sequence will be returned to
 the client in order.
 
-You can call `wire-up/start-responder!` multiple times to start
-different threads running the same handler.
+`wire-up/start-responder!` and `wire-up/start-streaming-responder!`
+all take an extra optional argument for the number of threads to take
+and handle messages on. The default is 10.
 
 Incoming messages are nacked if the thread is taking too long to
 process the messages. This allows different instances of the service
@@ -147,6 +157,12 @@ to process those messages.
 `in-channel` should be an unbuffered channel. `out-channel` should
 have a large buffer to get messages out to RabbitMQ as soon as
 possible.
+
+`wire-up/incoming-service` takes an optional argument
+`ignore-no-reply-to`. If true, kehaar will not log when an incomming
+message is missing the `:reply-to` metadata key. This will help
+prevent noise in the logs if the request comes from
+`async->fire-and-forget-fn`.
 
 * You want to listen for events on the events exchange. (First declare
   the exchange above, only do that once.)
@@ -181,7 +197,8 @@ a core.async channel that will include the result (also must be
 edenizable). That second option lets you maintain asynchrony because
 other services using kehaar are doing the same.
 
-Each call to `wire-up/start-event-handler!` creates a new thread.
+`wire-up/start-event-handler!` takes an optional argument for the
+number of threads to take and handle messages on. The default is 10.
 
 Incoming messages are nacked if the thread is taking too long to
 process the messages. This allows different instances of the service

--- a/example/project.clj
+++ b/example/project.clj
@@ -3,8 +3,8 @@
   :url "http://example.com/FIXME"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.7.0"]
-                 [democracyworks/kehaar "0.6.1-SNAPSHOT"]]
+  :dependencies [[org.clojure/clojure "1.8.0"]
+                 [democracyworks/kehaar "0.7.1-SNAPSHOT"]]
   :main kehaar-example.core
   :aliases {"streaming-producer" ["run" "-m" "kehaar-example.streaming.producer"]
             "streaming-consumer" ["run" "-m" "kehaar-example.streaming.consumer"]})

--- a/example/src/kehaar_example/streaming/producer.clj
+++ b/example/src/kehaar_example/streaming/producer.clj
@@ -14,7 +14,6 @@
 (defn -main [& args]
   (log/info "Producer starting up...")
   (let [connection (kehaar-rabbit/connect-with-retries)]
-
     (configure/configure!
      connection
      {:incoming-services [{:streaming? true

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject democracyworks/kehaar "0.6.1-SNAPSHOT"
+(defproject democracyworks/kehaar "0.8.0-SNAPSHOT"
   :url "https://github.com/democracyworks/kehaar"
   :description "Kehaar passes messages to and from RabbitMQ channels"
   :license {:name "Eclipse Public License"

--- a/src/kehaar/configure.clj
+++ b/src/kehaar/configure.clj
@@ -1,6 +1,7 @@
 (ns kehaar.configure
   (:require [kehaar.wire-up :as wire-up]
-            [clojure.core.async :as async]))
+            [clojure.core.async :as async]
+            [langohr.basic :as lb]))
 
 (def default-thread-count 10)
 
@@ -10,7 +11,8 @@
       (require ns'))))
 
 (defn configure! [connection configuration]
-  (let [{:keys [incoming-services external-services incoming-events
+  (let [rabbit-channels (atom #{})
+        {:keys [incoming-services external-services incoming-events
                 outgoing-events threads]}
         configuration]
     (doseq [{:keys [f threshold queue queue-options streaming?]}
@@ -18,20 +20,23 @@
       (require-ns f)
       (let [in-chan (async/chan)
             out-chan (async/chan)
-            f-var (find-var f)]
-        (wire-up/incoming-service connection
-                                  queue
-                                  queue-options
-                                  in-chan
-                                  out-chan)
+            f-var (find-var f)
+            thread-count (or threads default-thread-count)
+            rabbit-ch (wire-up/incoming-service connection
+                                                queue
+                                                queue-options
+                                                in-chan
+                                                out-chan)]
+        (lb/qos rabbit-ch thread-count)
+        (swap! rabbit-channels conj rabbit-ch)
+
         (if streaming?
           (wire-up/start-streaming-responder! connection
                                               in-chan
                                               out-chan
                                               f-var
                                               threshold
-                                              (or threads
-                                                  default-thread-count))
+                                              thread-count)
           (wire-up/start-responder! in-chan
                                     out-chan
                                     f-var
@@ -39,41 +44,43 @@
     (doseq [{:keys [streaming? exchange queue queue-options timeout f]}
             external-services]
       (require-ns f)
-      (let [channel (async/chan 100)]
-        (let [external-service-fn (if streaming?
-                                    wire-up/streaming-external-service
-                                    wire-up/external-service)]
-          (alter-var-root (find-var f)
-                          (constantly (wire-up/async->fn channel)))
-          (external-service-fn connection
-                               exchange
-                               queue
-                               queue-options
-                               timeout
-                               channel))))
+      (let [channel (async/chan 100)
+            external-service-fn (if streaming?
+                                  wire-up/streaming-external-service
+                                  wire-up/external-service)]
+        (alter-var-root (find-var f)
+                        (constantly (wire-up/async->fn channel)))
+        (swap! rabbit-channels conj
+               (external-service-fn connection
+                                    exchange
+                                    queue
+                                    queue-options
+                                    timeout
+                                    channel))))
     (doseq [{:keys [queue queue-options topic routing-key timeout f threads]}
             incoming-events]
       (require-ns f)
-      (let [channel (async/chan 100)]
-        (wire-up/incoming-events-channel connection
-                                         queue
-                                         queue-options
-                                         topic
-                                         routing-key
-                                         channel
-                                         timeout)
-        (wire-up/start-event-handler! channel (find-var f)
-                                      (or threads default-thread-count))))
+      (let [channel (async/chan 100)
+            rabbit-ch (wire-up/incoming-events-channel connection
+                                                       queue
+                                                       queue-options
+                                                       topic
+                                                       routing-key
+                                                       channel
+                                                       timeout)
+            thread-count (or threads default-thread-count)]
+        (lb/qos rabbit-ch thread-count)
+        (swap! rabbit-channels conj rabbit-ch)
+        (wire-up/start-event-handler! channel (find-var f) thread-count)))
     (doseq [{:keys [topic routing-key channel]}
             outgoing-events]
       (require-ns channel)
-      (wire-up/outgoing-events-channel connection
-                                       topic
-                                       routing-key
-                                       (var-get (find-var channel))))))
-
-;;; TODO: return all channels created... or register an exit handler
-;;; that will close them?
+      (swap! rabbit-channels conj
+             (wire-up/outgoing-events-channel connection
+                                              topic
+                                              routing-key
+                                              (var-get (find-var channel)))))
+    @rabbit-channels))
 
 ;;; TODO: provide some defaults (like :or {exchange ""}) for some
 ;;; sensible defaults: exchange, timeout, queue-options(?)

--- a/src/kehaar/wire_up.clj
+++ b/src/kehaar/wire_up.clj
@@ -41,40 +41,32 @@
     (langohr.exchange/declare ch name type options)
     ch))
 
-(def default-thread-count 10)
-
 (defn start-event-handler!
   "Start new threads listening for messages on `channel` and passing
   them to `handler`. Will loop over all messages, logging errors. When
-  `channel` is closed, stop looping."
-  ([channel handler]
-   (start-event-handler! channel handler default-thread-count))
-  ([channel handler threads]
-   (kehaar.core/thread-handler channel handler threads)))
+  `channel` is closed, stop looping. It will start `threads` number of
+  threads to process incoming messages."
+  [channel handler threads]
+  (kehaar.core/thread-handler channel handler threads))
 
 (defn start-responder!
-  "Start new threads that listen on in-channel and responds on
-  out-channel."
-  ([in-channel out-channel f]
-   (start-responder! in-channel out-channel f default-thread-count))
-  ([in-channel out-channel f threads]
-   (kehaar.core/thread-handler
-    in-channel
-    (kehaar.core/responder-fn out-channel f)
-    threads)))
+  "Start `threads` new threads that listen on `in-channel` and responds on
+  `out-channel`."
+  [in-channel out-channel f threads]
+  (kehaar.core/thread-handler
+   in-channel
+   (kehaar.core/responder-fn out-channel f)
+   threads))
 
 (defn start-streaming-responder!
-  "Start new threads that listen on in-channel and respond on
+  "Start `threads` new threads that listen on in-channel and respond on
   out-channel. threshold is the number of elements beyond which they
   should be placed on a bespoke RabbitMQ for the consumer."
-  ([connection in-channel out-channel f threshold]
-   (start-streaming-responder! connection in-channel out-channel
-                               f threshold default-thread-count))
-  ([connection in-channel out-channel f threshold threads]
-   (kehaar.core/thread-handler
-    in-channel
-    (kehaar.core/streaming-responder-fn connection out-channel f threshold)
-    threads)))
+  [connection in-channel out-channel f threshold threads]
+  (kehaar.core/thread-handler
+   in-channel
+   (kehaar.core/streaming-responder-fn connection out-channel f threshold)
+   threads))
 
 (defn incoming-service
   "Wire up an incoming channel and an outgoing channel. Later, you

--- a/src/kehaar/wire_up.clj
+++ b/src/kehaar/wire_up.clj
@@ -41,29 +41,40 @@
     (langohr.exchange/declare ch name type options)
     ch))
 
+(def default-thread-count 10)
+
 (defn start-event-handler!
-  "Start a new thread listening for messages on `channel` and passing
+  "Start new threads listening for messages on `channel` and passing
   them to `handler`. Will loop over all messages, logging errors. When
   `channel` is closed, stop looping."
-  [channel handler]
-  (kehaar.core/thread-handler channel handler))
+  ([channel handler]
+   (start-event-handler! channel handler default-thread-count))
+  ([channel handler threads]
+   (kehaar.core/thread-handler channel handler threads)))
 
 (defn start-responder!
-  "Start a new thread that listens on in-channel and responds on
+  "Start new threads that listen on in-channel and responds on
   out-channel."
-  [in-channel out-channel f]
-  (kehaar.core/thread-handler
-   in-channel
-   (kehaar.core/responder-fn out-channel f)))
+  ([in-channel out-channel f]
+   (start-responder! in-channel out-channel f default-thread-count))
+  ([in-channel out-channel f threads]
+   (kehaar.core/thread-handler
+    in-channel
+    (kehaar.core/responder-fn out-channel f)
+    threads)))
 
 (defn start-streaming-responder!
-  "Start a new thread that listens on in-channel and responds on
+  "Start new threads that listen on in-channel and respond on
   out-channel. threshold is the number of elements beyond which they
   should be placed on a bespoke RabbitMQ for the consumer."
-  [connection in-channel out-channel f threshold]
-  (kehaar.core/thread-handler
-   in-channel
-   (kehaar.core/streaming-responder-fn connection out-channel f threshold)))
+  ([connection in-channel out-channel f threshold]
+   (start-streaming-responder! connection in-channel out-channel
+                               f threshold default-thread-count))
+  ([connection in-channel out-channel f threshold threads]
+   (kehaar.core/thread-handler
+    in-channel
+    (kehaar.core/streaming-responder-fn connection out-channel f threshold)
+    threads)))
 
 (defn incoming-service
   "Wire up an incoming channel and an outgoing channel. Later, you
@@ -71,12 +82,14 @@
   function.
 
   Returns a langohr channel. Please close it on exit."
-  [connection queue-name options in-channel out-channel]
-  (let [ch (langohr.channel/open connection)]
-    (langohr.queue/declare ch queue-name options)
-    (kehaar.core/rabbit=>async ch queue-name in-channel)
-    (kehaar.core/async=>rabbit-with-reply-to out-channel ch)
-    ch))
+  ([connection queue-name options in-channel out-channel]
+   (incoming-service connection "" queue-name options in-channel out-channel false))
+  ([connection exchange queue-name options in-channel out-channel ignore-no-reply-to]
+   (let [ch (langohr.channel/open connection)]
+     (langohr.queue/declare ch queue-name options)
+     (kehaar.core/rabbit=>async ch queue-name in-channel)
+     (kehaar.core/async=>rabbit-with-reply-to out-channel ch exchange ignore-no-reply-to)
+     ch)))
 
 (defn external-service
   "Wires up a core.async channel to a RabbitMQ queue that provides
@@ -125,6 +138,23 @@
             (when-let [chan (get @pending-calls correlation-id)]
               (async/close! chan)
               (swap! pending-calls dissoc correlation-id))))))
+     ch)))
+
+(defn external-service-fire-and-forget
+  "Wires up a core.async channel to a RabbitMQ queue. Just put a
+  message on the channel. Use `async->fire-and-forget-fn` to create a
+  function that puts to that channel."
+  ([connection queue-name channel]
+   (external-service connection ""
+                     queue-name {:exclusive false
+                                 :durable true
+                                 :auto-delete false}
+                     channel))
+  ([connection exchange queue-name queue-options channel]
+   (let [ch (langohr.channel/open connection)]
+     (langohr.queue/declare ch queue-name queue-options)
+
+     (kehaar.core/async=>rabbit channel ch exchange queue-name)
      ch)))
 
 (defn streaming-external-service
@@ -225,3 +255,14 @@
     (let [response-channel (async/chan 1)]
       (async/>!! channel [response-channel message])
       response-channel)))
+
+(defn async->fire-and-forget-fn
+  "Returns a fn that takes a message and puts message and metadata on
+  the channel. Returns the value of async/>!! which returns true if it
+  was successfull putting a message on the channel."
+  ([channel]
+   (async->fire-and-forget-fn channel {}))
+  ([channel metadata]
+   (fn [message]
+     (async/>!! channel {:metadata metadata
+                         :message message}))))

--- a/test/kehaar/core_test.clj
+++ b/test/kehaar/core_test.clj
@@ -75,7 +75,7 @@
           results-channel (async/chan 3)
           f (fn [n]
               (async/>!! results-channel (/ 1 n)))]
-      (thread-handler channel f)
+      (thread-handler channel f 1)
       (async/>!! channel 2)
       (async/>!! channel 0)
       (async/>!! channel 3)


### PR DESCRIPTION
This contains a master merge and adds thread count setting from the config data structure and then sets the prefetch limits based on that thread count.

Since I needed to gather all of the RabbitMQ channels to set the prefetch limits on them, I also opportunistically knocked out (one way of) returning all of those channels from `configure!`. Also happy to change or excise that if you'd rather.
