### PR TITLE
Jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Some notes:
   async channel to put results on, the routing key for the job, and
   the message from the process that requested the job. The message has
   been serialized and deserialized as EDN. So expect any kind of
-  serializable value.
+  serializable value. The async channel must be closed when finished.
 
 ##### You want to subcontract work from one job service to another
 

--- a/README.md
+++ b/README.md
@@ -27,11 +27,12 @@ docstrings for all available options.
 
 You can use `kehaar.configured/init!` to set up all the below examples
 in one go by passing a map with the keys `:event-exchanges`,
-`:incoming-services`, `:external-services`, `:incoming-events`, and
-`:outgoing-events`, each with a sequence of the maps for each kind of
-thing. The return value of which is a collection of all the
-shutdownable resources created in the process, and it may be passed to
-`kehaar.configured/shutdown!` to clean them all up.
+`:incoming-services`, `:external-services`, `:incoming-events`,
+`:outgoing-events`, `:incoming-jobs`, and `:outgoing-jobs` each with a
+sequence of the maps for each kind of thing. The return value of which
+is a collection of all the shutdownable resources created in the
+process, and it may be passed to `kehaar.configured/shutdown!` to
+clean them all up.
 
 #### Examples
 
@@ -101,6 +102,63 @@ Some notes:
 * If `:response` is `nil`, kehaar will not log error messages when the
   incoming messages lack a reply-to queue. This can reduce log noise
   if `:response` is set to `nil` on the request side.
+
+##### You want to request work be done by a "job" service.
+
+```clojure
+(kehaar.configured/init-outgoing-job!
+ connection
+ {:jobs-chan 'fully.qualified/job-request-channel
+  :queue "service.works.service.perform-job"})
+```
+
+Then you can create a function that "calls" that job service, like so:
+
+```clojure
+(def kick-off-job (jobs/async->job job-request-channel))
+```
+
+The returned function takes two arguments, the message to send to the
+job service, which must be some ednizable value, and a function to
+handle results from the service(s) producing them for the job. The
+returned function's return value is the routing key created for the
+job, but you are unlikely to need it.
+
+##### You want to create a "job" service.
+
+```clojure
+(kehaar.configured/init-incoming-job!
+ connection
+ {:queue "service.works.service.perform-job"
+  :f 'fully.qualified/handler-function})
+```
+
+Some notes:
+
+* The handler function must be a function of three arguments: a core
+  async channel to put results on, the routing key for the job, and
+  the message from the process that requested the job. The message has
+  been serialized and deserialized as EDN. So expect any kind of
+  serializable value.
+
+##### You want to subcontract work from one job service to another
+
+```clojure
+(kehaar.configured/init-outgoing-job!
+ connection
+ {:jobs-chan 'fully.qualified/subcontract-channel
+  :queue "service.works.service.subcontract-part-of-job"})
+```
+
+Then you create a function that calls that job service as a
+subcontractor, like so:
+
+```clojure
+(def subcontract-job (jobs/async->subjob subcontract-channel))
+```
+
+The returned function takes two arguments: the routing key for the
+current job, and the message to send.
 
 ##### You want to listen for events on a topic.
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,11 @@ clean them all up.
 
 #### Examples
 
-Assuming that a rabbitmq connection is available as `connection`.
+> All examples are exercised by the example project. See
+> example/README.md for details.
+
+The following assumes that a rabbitmq connection is available as
+`connection`.
 
 Some typical patterns:
 

--- a/example/README.md
+++ b/example/README.md
@@ -12,9 +12,28 @@ reacts to it.
 This project assumes a RabbitMQ server running locally on its standard
 port.
 
-To run the project: `lein run`.
+### Standard response/request and event functionality
+
+Execute `lein run`.
 
 It will make 500 requests to the Fibonacci service, logging requests,
 responses and events received.
 
-See the core.clj for details.
+See core.clj for details.
+
+### Streaming functionality
+
+Run `lein streaming-producer` in one terminal and `lein
+streaming-consumer` in another. The consumer will make requests to the
+producer which will stream them back.
+
+See streaming/producer.clj and streaming/consumer.clj.
+
+### Jobs
+
+Run `lein job-threes` and `lein job-counter` in two terminals and then
+`lein job-instigator` in a third terminal. The instigator will make a
+job request to the counter, which will start sending results, but will
+also subcontract some of the work to the "threes" worker.
+
+See jobs/threes.clj, jobs/counter.clj, and jobs/instigator.clj.

--- a/example/project.clj
+++ b/example/project.clj
@@ -4,7 +4,10 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.7.0"]
-                 [democracyworks/kehaar "0.8.1"]]
+                 [democracyworks/kehaar "0.8.2-SNAPSHOT"]]
   :main kehaar-example.core
   :aliases {"streaming-producer" ["run" "-m" "kehaar-example.streaming.producer"]
-            "streaming-consumer" ["run" "-m" "kehaar-example.streaming.consumer"]})
+            "streaming-consumer" ["run" "-m" "kehaar-example.streaming.consumer"]
+            "job-instigator" ["run" "-m" "kehaar-example.jobs.instigator"]
+            "job-counter" ["run" "-m" "kehaar-example.jobs.counter"]
+            "job-threes" ["run" "-m" "kehaar-example.jobs.threes"]})

--- a/example/src/kehaar_example/jobs/counter.clj
+++ b/example/src/kehaar_example/jobs/counter.clj
@@ -1,0 +1,39 @@
+(ns kehaar-example.jobs.counter
+  "This is a service that provides work for requested jobs. In this
+  case, it replies to jobs from the instigator service and
+  subcontracts some of its work to the threes service."
+  (:require [clojure.core.async :as async]
+            [clojure.tools.logging :as log]
+            [kehaar.configured :as kehaar]
+            [kehaar.jobs :as jobs]
+            [kehaar.rabbitmq :as kehaar-rabbit]))
+
+(def three-subjob (async/chan))
+
+(def subcontract-three (jobs/async->subjob three-subjob))
+
+(defn job-handler [out-chan routing-key message]
+  (log/info "Got job, routing-key:" routing-key)
+  (dotimes [n 5]
+    (if (= n 3)
+      (subcontract-three routing-key n)
+      (do
+        (Thread/sleep (rand-int 2000))
+        (async/>!! out-chan (str n "-" message)))))
+  (async/close! out-chan))
+
+(def config
+  {:incoming-jobs [{:f 'kehaar-example.jobs.counter/job-handler
+                    :queue "counting-job"}]
+   :outgoing-jobs [{:jobs-chan 'kehaar-example.jobs.counter/three-subjob
+                    :queue "do-fizz"}]})
+
+(defn setup []
+  (let [connection (kehaar-rabbit/connect-with-retries)]
+    (kehaar/init! connection config)))
+
+(defn -main [& args]
+  (log/info "Starting counter")
+  (setup)
+  (log/info "Started")
+  (.join (Thread/currentThread)))

--- a/example/src/kehaar_example/jobs/instigator.clj
+++ b/example/src/kehaar_example/jobs/instigator.clj
@@ -1,0 +1,48 @@
+(ns kehaar-example.jobs.instigator
+  "This is a service which requests jobs via the counting-job
+  channel. Those jobs are worked on by the counter service, which
+  subcontracts some of its work to the threes service."
+  (:require [clojure.core.async :as async]
+            [clojure.tools.logging :as log]
+            [kehaar.configured :as kehaar]
+            [kehaar.jobs :as jobs]
+            [kehaar.rabbitmq :as kehaar-rabbit]))
+
+(def job-request-chan
+  (async/chan))
+
+(def request-job
+  (jobs/async->job job-request-chan))
+
+(def config
+  {:outgoing-jobs [{:jobs-chan 'kehaar-example.jobs.instigator/job-request-chan
+                    :queue "counting-job"}]})
+
+(defn make-job-handler [id n]
+  (fn [message]
+    (if (= 0 (rand-int 5))
+      (do
+        (log/info "Stopping job" id "/" n)
+        ::jobs/stop)
+      (log/info "Got response:" id "/" n "-" (pr-str message)))))
+
+(defn setup []
+  (let [connection (kehaar-rabbit/connect-with-retries)]
+    (kehaar/init! connection config)))
+
+(defn -main [& args]
+  (log/info "Starting instigator")
+  (setup)
+  (log/info "Started")
+
+  (let [id (rand-int 100)]
+
+    (log/info "id:" id)
+
+    (dotimes [n 10]
+      (log/info "Requesting job" n)
+      (request-job
+       {:n n :id id}
+       (make-job-handler id n)))
+
+    (.join (Thread/currentThread))))

--- a/example/src/kehaar_example/jobs/threes.clj
+++ b/example/src/kehaar_example/jobs/threes.clj
@@ -1,0 +1,27 @@
+(ns kehaar-example.jobs.threes
+  "This is a service that provides work for requested jobs. In this
+  case, it is called as a subjob from the counter service."
+  (:require [clojure.core.async :as async]
+            [clojure.tools.logging :as log]
+            [kehaar.configured :as kehaar]
+            [kehaar.jobs :as jobs]
+            [kehaar.rabbitmq :as kehaar-rabbit]))
+
+(defn job-handler [out-chan routing-key message]
+  (log/info "Got job, routing-key:" routing-key)
+  (async/>!! out-chan :fizz)
+  (async/close! out-chan))
+
+(def config
+  {:incoming-jobs [{:f 'kehaar-example.jobs.threes/job-handler
+                    :queue "do-fizz"}]})
+
+(defn setup []
+  (let [connection (kehaar-rabbit/connect-with-retries)]
+    (kehaar/init! connection config)))
+
+(defn -main [& args]
+  (log/info "Starting threes")
+  (setup)
+  (log/info "Started")
+  (.join (Thread/currentThread)))

--- a/src/kehaar/configured.clj
+++ b/src/kehaar/configured.clj
@@ -294,7 +294,7 @@
         outgoing-ch (langohr.channel/open connection)]
     (lq/declare outgoing-ch queue queue-options)
     (kehaar.core/async=>rabbit channel-val outgoing-ch exchange queue)
-    (if-not @outgoing-jobs-initialized?
+    (when-not @outgoing-jobs-initialized?
       (let [response-ch (langohr.channel/open connection)
             response-queue (lq/declare-server-named response-ch)
             worker-ch (langohr.channel/open connection)
@@ -333,8 +333,8 @@
                               {:keys [::jobs/routing-key]} m]
                           (when (get @jobs/jobs routing-key)
                             (jobs/add-worker! routing-key))))
-                      {:auto-ack true}))
-      {:rabbit-channel outgoing-ch})))
+                      {:auto-ack true})))
+    {:rabbit-channel outgoing-ch}))
 
 (defn init-incoming-job!
   "Initializes a service that accepts messages on a queue and will

--- a/src/kehaar/configured.clj
+++ b/src/kehaar/configured.clj
@@ -1,8 +1,14 @@
 (ns kehaar.configured
   (:require [kehaar.wire-up :as wire-up]
+            [kehaar.jobs :as jobs]
+            [kehaar.core]
             [clojure.core.async :as async]
+            [clojure.tools.logging :as log]
             [langohr.core :as rmq]
-            [langohr.basic :as lb]))
+            [langohr.basic :as lb]
+            [langohr.channel :as lchan]
+            [langohr.consumers :as lc]
+            [langohr.queue :as lq]))
 
 (def ^:const default-exchange "")
 (def ^:const default-exchange-options {:auto-delete false :durable true})
@@ -19,27 +25,27 @@
 (defn init-exchange!
   "Initializes an exchange.
 
-Arguments:
-* `connection`: A rabbitmq connection
-* `exchange-options`: A map defining the exchange
+  Arguments:
+  * `connection`: A rabbitmq connection
+  * `exchange-options`: A map defining the exchange
 
-Valid keys for the `exchange-options` are:
-* `:exchange`: The name of the exchange (required)
-* `:type`: The type of the exchange (optional, default `\"topic\"`)
-* `:options`: The options map passed to `langohr.exchange/declare`
+  Valid keys for the `exchange-options` are:
+  * `:exchange`: The name of the exchange (required)
+  * `:type`: The type of the exchange (optional, default `\"topic\"`)
+  * `:options`: The options map passed to `langohr.exchange/declare`
   (optional, default {:auto-delete false :durable true})
 
-Returns a map with one key, `:rabbit-channel`, the value of which is
-the channel created as a side-effect of declaring the exchange. The
-map may be passed to `shutdown-part!` to clean it up.
+  Returns a map with one key, `:rabbit-channel`, the value of which is
+  the channel created as a side-effect of declaring the exchange. The
+  map may be passed to `shutdown-part!` to clean it up.
 
-Example:
+  Example:
 
-```
-(init-exchange! connection {:exchange \"events\"})
-```
+  ```
+  (init-exchange! connection {:exchange \"events\"})
+  ```
 
-That will create a topic exchange named \"events\"."
+  That will create a topic exchange named \"events\"."
   [connection
    {:keys [exchange type options]
     :or {type "topic"
@@ -54,35 +60,35 @@ That will create a topic exchange named \"events\"."
 
 (defn init-incoming-service!
   "Initializes a service that accepts messages on a queue which may
-reply with results.
+  reply with results.
 
-Arguments:
-* `connection`: A rabbitmq connection
-* `incoming-service-options`: A map defining the service
+  Arguments:
+  * `connection`: A rabbitmq connection
+  * `incoming-service-options`: A map defining the service
 
-Valid keys for the `incoming-service-options` are:
-* `:f`: A fully qualified symbol for the function that will be called
+  Valid keys for the `incoming-service-options` are:
+  * `:f`: A fully qualified symbol for the function that will be called
   for every message received on the queue. It must be a function of
   one argument, which will be a serializable Clojure value. For
   `:streaming` responses, it must return a sequence. For `:streaming`
   or `true` responses, it must return a serializable Clojure
   value. (required)
-* `:queue`: The name of the queue to listen for requests on. (required)
-* `:queue-options`: The options map passed to `langohr.queue/declare`
+  * `:queue`: The name of the queue to listen for requests on. (required)
+  * `:queue-options`: The options map passed to `langohr.queue/declare`
   for the queue. (optional, default {:auto-delete false :durable true
   :exclusive false})
-* `:response`: How to respond. Key should be `nil`, `:streaming` or
+  * `:response`: How to respond. Key should be `nil`, `:streaming` or
   `true`. `nil` means don't return the result of the function to the
   caller. `:streaming` means the function will return a sequence, the
   values of which will be returned to the caller one by one. `true`
   means return the result of the function in one message back to the
   caller. (optional, default `nil`)
-* `:exchange`: The name of the exchange. (optional, default `\"\"`)
-* `:prefetch-limit`: The number of messages to prefetch from the
+  * `:exchange`: The name of the exchange. (optional, default `\"\"`)
+  * `:prefetch-limit`: The number of messages to prefetch from the
   queue. (optional, default 1).
-* `:threads`: The number of threads to run, each listening for and
+  * `:threads`: The number of threads to run, each listening for and
   handling messages from the queue. (optional, default 10)
-* `:threshold`: For `:streaming` responses, the number of values at
+  * `:threshold`: For `:streaming` responses, the number of values at
   which to switch from replying on default response queue to replying
   on a bespoke queue for the caller. (optional, default 10)"
   [connection
@@ -126,30 +132,30 @@ Valid keys for the `incoming-service-options` are:
 
 (defn init-external-service!
   "Initializes an external service to send requests to via a queue
-which may reply with results.
+  which may reply with results.
 
-Arguments:
-* `connection`: A rabbitmq connection
-* `external-service-options`: A map defining the service
+  Arguments:
+  * `connection`: A rabbitmq connection
+  * `external-service-options`: A map defining the service
 
-Valid keys for the `external-service-options` are:
-* `:channel`: A fully qualified symbol for the core.async channel that
+  Valid keys for the `external-service-options` are:
+  * `:channel`: A fully qualified symbol for the core.async channel that
   requests to the service are placed on. Separately, this channel
   should be passed to `wire-up/async->fn` or
   `wire-up/async->fire-and-forget-fn` to complete the setup for
   calling the external service. (required)
-* `:queue`: The name of the queue used by the service. (required)
-* `:queue-options`: The options map passed to `langohr.queue/declare`
+  * `:queue`: The name of the queue used by the service. (required)
+  * `:queue-options`: The options map passed to `langohr.queue/declare`
   for the queue. (optional, default {:auto-delete false :durable true
   :exclusive false})
-* `:response`: How responses are received. Key should be `nil`,
+  * `:response`: How responses are received. Key should be `nil`,
   `:streaming` or `true`. `nil` means no response will be
   received. `:streaming` means multiple values may come from the
   response channel before it is closed. `true` means only one value
   will come from the response channel. Should match the value used on
   the other side. (optional, default `nil`)
-* `:exchange`: The name of the exchange. (optional, default `\"\"`)
-* `:timeout`: The number of milliseconds to wait for a response from
+  * `:exchange`: The name of the exchange. (optional, default `\"\"`)
+  * `:timeout`: The number of milliseconds to wait for a response from
   the service before giving up. (optional, default 1000)"
   [connection
    {:keys [response exchange queue queue-options timeout channel]
@@ -186,27 +192,27 @@ Valid keys for the `external-service-options` are:
 (defn init-incoming-event!
   "Initializes a handler for incoming messages from a rabbit topic.
 
-Arguments:
-* `connection`: A rabbitmq connection
-* `incoming-event-options`: A map defining the event handler
+  Arguments:
+  * `connection`: A rabbitmq connection
+  * `incoming-event-options`: A map defining the event handler
 
-Valid keys for the `incoming-event-options` are:
-* `:f`: A fully qualified symbol for the function that will be called
+  Valid keys for the `incoming-event-options` are:
+  * `:f`: A fully qualified symbol for the function that will be called
   for every message received for the subscribed topic. It must be a
   function of one argument, which will be a serializable Clojure
   value. (required)
-* `:routing-key`: The routing key being listened for. (required)
-* `:queue`: The name of the queue that will be bound to the
+  * `:routing-key`: The routing key being listened for. (required)
+  * `:queue`: The name of the queue that will be bound to the
   routing-key. (required)
-* `:queue-options`: The options map passed to `langohr.queue/declare`
+  * `:queue-options`: The options map passed to `langohr.queue/declare`
   for the queue. (optional, default {:auto-delete false :durable true
   :exclusive false})
-* `:exchange`: The name of the exchange. (optional, default `\"\"`)
-* `:prefetch-limit`: The number of messages to prefetch from the
+  * `:exchange`: The name of the exchange. (optional, default `\"\"`)
+  * `:prefetch-limit`: The number of messages to prefetch from the
   queue. (optional, default 1).
-* `:threads`: The number of threads to run, each listening for and
+  * `:threads`: The number of threads to run, each listening for and
   handling events. (optional, default 10)
-* `:timeout`: The number of milliseconds to wait for a message being
+  * `:timeout`: The number of milliseconds to wait for a message being
   accepted for processing before nacking. (optional, default 1000)"
   [connection
    {:keys [queue queue-options exchange routing-key timeout f
@@ -235,17 +241,17 @@ Valid keys for the `incoming-event-options` are:
 (defn init-outgoing-event!
   "Initializes a core.async channel for sending messages to a topic.
 
-Arguments:
-* `connection`: A rabbitmq connection
-* `outgoing-event-options`: A map defining the channel and topic.
+  Arguments:
+  * `connection`: A rabbitmq connection
+  * `outgoing-event-options`: A map defining the channel and topic.
 
-Valid keys for the `outgoing-event-options` are:
-* `:routing-key`: The routing key used for outgoing
+  Valid keys for the `outgoing-event-options` are:
+  * `:routing-key`: The routing key used for outgoing
   messages. (required)
-* `:channel`: A fully qualified symbol for the core.async channel from
+  * `:channel`: A fully qualified symbol for the core.async channel from
   which messages will be sent to rabbit. Only serializable values may
   be placed on that channel. (required)
-* `:exchange`: The name of the exchange. (optional, default `\"\"`)"
+  * `:exchange`: The name of the exchange. (optional, default `\"\"`)"
   [connection
    {:keys [exchange routing-key channel]
     :or {exchange default-exchange}}]
@@ -259,6 +265,126 @@ Valid keys for the `outgoing-event-options` are:
                    out-channel)]
 
     {:rabbit-channel rabbit-ch}))
+
+(def outgoing-job-channel-initialized?
+  (atom false))
+
+(defn init-outgoing-job!
+  "Initializes a queue for sending job requests on.
+
+  Arguments:
+  * `connection`: A rabbitmq connection
+  * `outgoing-job-options`: A map describing the job channel and queue.
+
+  Valid keys for the `outgoing-job-options` are:
+  * `:jobs-chan`: A fully qualified symbol for the core.async channel
+  from which messages will be sent to rabbit. Only serializable values
+  may be placed on that channel. (required)
+  * `:queue`: The name of the queue that will be bound to the
+  routing-key. (required)
+  * `:queue-options`: The options map passed to `langohr.queue/declare`
+  for the queue. (optional, default {:auto-delete false :durable true
+  :exclusive false})
+  * `:exchange`: The name of the exchange. (optional, default `\"\"`)"
+  [connection {:keys [jobs-chan queue queue-options exchange]
+               :or {queue-options default-queue-options
+                    exchange default-exchange}}]
+  (require-ns jobs-chan)
+  (let [channel-val (var-get (find-var jobs-chan))
+        outgoing-ch (langohr.channel/open connection)]
+    (lq/declare outgoing-ch queue queue-options)
+    (kehaar.core/async=>rabbit channel-val outgoing-ch exchange queue)
+    (if-not @outgoing-job-channel-initialized?
+      (let [response-ch (langohr.channel/open connection)
+            response-queue (lq/declare-server-named response-ch)
+            worker-ch (langohr.channel/open connection)
+            worker-queue (lq/declare-server-named response-ch)]
+        (reset! outgoing-job-channel-initialized? true)
+
+        (lb/qos response-ch 1)
+        (lq/bind response-ch
+                 response-queue
+                 jobs/kehaar-exchange
+                 {:routing-key "kehaar-job.*"})
+        (lc/subscribe response-ch response-queue
+                      (fn [ch metadata ^bytes payload]
+                        (let [m (kehaar.core/read-payload payload)
+                              {:keys [::jobs/routing-key
+                                      ::jobs/message]} m]
+                          (when-let [handler (get-in @jobs/jobs [routing-key :handler])]
+                            (if (= ::jobs/complete message)
+                              (do
+                                (jobs/complete! routing-key)
+                                (when (zero? (get-in @jobs/jobs [routing-key :workers]))
+                                  (jobs/cancel! routing-key)))
+                              (let [result (handler message)]
+                                (when (= ::jobs/stop result)
+                                  (jobs/cancel! routing-key)))))))
+                      {:auto-ack true})
+
+        (lb/qos worker-ch 1)
+        (lq/bind worker-ch
+                 worker-queue
+                 jobs/kehaar-exchange
+                 {:routing-key "kehaar-worker"})
+        (lc/subscribe worker-ch worker-queue
+                      (fn [ch metadata ^bytes payload]
+                        (let [m (kehaar.core/read-payload payload)
+                              {:keys [::jobs/routing-key]} m]
+                          (when (get @jobs/jobs routing-key)
+                            (jobs/add-worker! routing-key))))
+                      {:auto-ack true}))
+      {:rabbit-channel outgoing-ch})))
+
+(defn init-incoming-job!
+  "Initializes a service that accepts messages on a queue and will
+  send results back asynchronously.
+
+  Arguments:
+  * `connection`: A rabbitmq connection
+  * `incoming-job-options`: A map defining the service
+
+  Valid keys for the `outgoing-event-options` are:
+  * `:f`: A fully qualified symbol for the function that will be
+  called for every message received for the subscribed topic. It must
+  be a function of three arguments, which will be a core.async a
+  channel to put results on, the routing-key for the job that may be
+  passed to further job services, and a serializable Clojure
+  value. (required)
+  * `:queue`: The name of the queue that will be bound to the
+  routing-key. (required)
+  * `:queue-options`: The options map passed to `langohr.queue/declare`
+  for the queue. (optional, default {:auto-delete false :durable true
+  :exclusive false})
+  * `:prefetch-limit`: The number of messages to prefetch from the
+  queue. (optional, default 1).
+  * `:threads`: The number of threads to run, each listening for and
+  handling events. (optional, default 10)"
+  [connection {:keys [f queue queue-options prefetch-limit threads]
+               :or {prefetch-limit default-prefetch-limit
+                    queue-options default-queue-options
+                    threads wire-up/default-thread-count}}]
+  (when-not @jobs/workers-chan-initialized?
+    (reset! jobs/workers-chan-initialized? true)
+    (let [work-ch (lchan/open connection)]
+      (kehaar.core/async=>rabbit jobs/workers-chan
+                                 work-ch
+                                 jobs/kehaar-exchange
+                                 "kehaar-worker")))
+  (require-ns f)
+  (let [f-var (find-var f)
+        in-chan (async/chan)
+        ch (lchan/open connection)]
+    (lq/declare ch queue queue-options)
+    (when prefetch-limit
+      (lb/qos ch prefetch-limit))
+    (kehaar.core/rabbit=>async ch queue in-chan queue-options 100)
+    (wire-up/start-jobs-handler! ch
+                                 in-chan
+                                 f-var
+                                 threads)
+    {:rabbit-channel ch
+     :async-channels {:in in-chan}}))
 
 (defn shutdown-part!
   "Closes rabbit channels and core.async channels created by any of
@@ -280,18 +406,25 @@ Valid keys for the `outgoing-event-options` are:
 
 (defn init!
   "Initializes multiple services in one go. Takes a rabbitmq
-connection and a configuration map.
+  connection and a configuration map.
 
-The configuration map can have the keys `event-exchanges`,
-`incoming-services`, `external-services`, `incoming-events`, and
-`outgoing-events`. Each key's value should be a sequence of maps
-appropriate for its initializer.
+  The configuration map can have the keys `event-exchanges`,
+  `incoming-services`, `external-services`, `incoming-events`, and
+  `outgoing-events`. Each key's value should be a sequence of maps
+  appropriate for its initializer.
 
-Returns a collection of resources that may be closed by `shutdown!`."
+  Returns a collection of resources that may be closed by `shutdown!`."
   [connection configuration]
-  (let [{:keys [event-exchanges incoming-services external-services incoming-events outgoing-events]}
+  (let [{:keys [event-exchanges
+                incoming-services
+                external-services
+                incoming-events
+                outgoing-events
+                incoming-jobs
+                outgoing-jobs]}
         configuration
         states (atom [])]
+    (init-exchange! connection {:exchange jobs/kehaar-exchange})
     (doseq [exchange event-exchanges]
       (swap! states conj (init-exchange! connection exchange)))
     (doseq [incoming-service incoming-services]
@@ -302,5 +435,9 @@ Returns a collection of resources that may be closed by `shutdown!`."
       (swap! states conj (init-incoming-event! connection incoming-event)))
     (doseq [outgoing-event outgoing-events]
       (swap! states conj (init-outgoing-event! connection outgoing-event)))
+    (doseq [incoming-job incoming-jobs]
+      (swap! states conj (init-incoming-job! connection incoming-job)))
+    (doseq [outgoing-job outgoing-jobs]
+      (swap! states conj (init-outgoing-job! connection outgoing-job)))
 
     @states))

--- a/src/kehaar/configured.clj
+++ b/src/kehaar/configured.clj
@@ -266,7 +266,7 @@
 
     {:rabbit-channel rabbit-ch}))
 
-(def outgoing-job-channel-initialized?
+(def outgoing-jobs-initialized?
   (atom false))
 
 (defn init-outgoing-job!
@@ -294,12 +294,12 @@
         outgoing-ch (langohr.channel/open connection)]
     (lq/declare outgoing-ch queue queue-options)
     (kehaar.core/async=>rabbit channel-val outgoing-ch exchange queue)
-    (if-not @outgoing-job-channel-initialized?
+    (if-not @outgoing-jobs-initialized?
       (let [response-ch (langohr.channel/open connection)
             response-queue (lq/declare-server-named response-ch)
             worker-ch (langohr.channel/open connection)
             worker-queue (lq/declare-server-named response-ch)]
-        (reset! outgoing-job-channel-initialized? true)
+        (reset! outgoing-jobs-initialized? true)
 
         (lb/qos response-ch 1)
         (lq/bind response-ch

--- a/src/kehaar/configured.clj
+++ b/src/kehaar/configured.clj
@@ -350,7 +350,8 @@
   be a function of three arguments, which will be a core.async a
   channel to put results on, the routing-key for the job that may be
   passed to further job services, and a serializable Clojure
-  value. (required)
+  value. The function must close the core.async channel when
+  finished. (required)
   * `:queue`: The name of the queue that will be bound to the
   routing-key. (required)
   * `:queue-options`: The options map passed to `langohr.queue/declare`

--- a/src/kehaar/core.clj
+++ b/src/kehaar/core.clj
@@ -116,8 +116,8 @@
    (async=>rabbit channel rabbit-channel "" queue))
   ([channel rabbit-channel exchange queue]
    (go-handler [{:keys [message metadata]} channel]
-               (lb/publish rabbit-channel exchange queue (pr-str message)
-                           metadata))))
+     (lb/publish rabbit-channel exchange queue (pr-str message)
+                 metadata))))
 
 (defn async=>rabbit-with-reply-to
   "Forward all messages on channel to the RabbitMQ queue specified in
@@ -200,9 +200,9 @@
                                :auto-delete true
                                :durable true})
               return-listener (lb/return-listener
-                                (fn [reply-code reply-text exchange routing-key
-                                     properties body]
-                                  (reset! stream? false)))]
+                               (fn [reply-code reply-text exchange routing-key
+                                    properties body]
+                                 (reset! stream? false)))]
           ;; add return listener
           (.addReturnListener ch return-listener)
           ;; put queue name on out-channel

--- a/src/kehaar/jobs.clj
+++ b/src/kehaar/jobs.clj
@@ -42,7 +42,8 @@
                 {::routing-key routing-key}})))
 
 (defn async=>rabbit
-  "A jobs-specific async=>rabbit for job handlers."
+  "A jobs-specific async=>rabbit for job handlers that publishes
+  a ::complete message once the channel is closed."
   [chan rabbit-ch exchange routing-key]
   (async/go-loop []
     (let [{:keys [:message :metadata] :as ch-message} (async/<! chan)]

--- a/src/kehaar/jobs.clj
+++ b/src/kehaar/jobs.clj
@@ -1,0 +1,77 @@
+(ns kehaar.jobs
+  (:require [clojure.core.async :as async]
+            [langohr.basic :as lb]))
+
+(def ^:const kehaar-exchange "kehaar")
+
+(def jobs (atom {}))
+
+(def workers-chan (async/chan))
+(def workers-chan-initialized? (atom false))
+
+(defn new-routing-key []
+  (str "kehaar-job." (java.util.UUID/randomUUID)))
+
+(defn async->job
+  "Like wire-up/async->fire-and-forget-fn, returns a function that
+  sends the appropriate message on the channel so it gets routed to
+  the appropriate service. Except it also takes a function to call
+  every time an event comes through. Returns the job's routing-key."
+  [chan]
+  (fn [message handler]
+    (let [routing-key (new-routing-key)]
+      (swap! jobs assoc routing-key {:handler handler
+                                     :workers 1})
+      (async/>!! chan
+                 {:message
+                  {::routing-key routing-key
+                   ::message message}})
+      routing-key)))
+
+(defn async->subjob
+  "Like async->job, but it's a 2-arity function that takes the
+  routing-key as an arg."
+  [chan]
+  (fn [routing-key message]
+    (async/>!! chan
+               {:message
+                {::routing-key routing-key
+                 ::message message}})
+    (async/>!! workers-chan
+               {:message
+                {::routing-key routing-key}})))
+
+(defn async=>rabbit
+  "A jobs-specific async=>rabbit for job handlers."
+  [chan rabbit-ch exchange routing-key]
+  (async/go-loop []
+    (let [{:keys [:message :metadata] :as ch-message} (async/<! chan)]
+      (if (nil? ch-message)
+        (lb/publish rabbit-ch
+                    exchange
+                    routing-key
+                    (pr-str {::message ::complete
+                             ::routing-key routing-key})
+                    {})
+        (do
+          (lb/publish rabbit-ch
+                      exchange
+                      routing-key
+                      (pr-str message)
+                      metadata)
+          (recur))))))
+
+(defn cancel!
+  "Cancel a job by its routing key."
+  [routing-key]
+  (swap! jobs dissoc routing-key))
+
+(defn complete!
+  "Record a completed worker."
+  [routing-key]
+  (swap! jobs update-in [routing-key :workers] dec))
+
+(defn add-worker!
+  "Record a new worker."
+  [routing-key]
+  (swap! jobs update-in [routing-key :workers] inc))

--- a/src/kehaar/wire_up.clj
+++ b/src/kehaar/wire_up.clj
@@ -83,6 +83,10 @@
     threads)))
 
 (defn start-jobs-handler!
+  "Start new threads that listen on in-channel, calling f for each
+  message. f must be a function of 3 arguments: a core.async channel
+  to send responses on, the routing-key of the job, and the message
+  received."
   [rabbit-channel in-chan f threads]
   (dotimes [n threads]
     (async/thread

--- a/src/kehaar/wire_up.clj
+++ b/src/kehaar/wire_up.clj
@@ -156,28 +156,28 @@
        (kehaar.core/rabbit=>async ch response-queue <response-channel
                                   {:exclusive true} 1000)
        (kehaar.core/go-handler
-           [{:keys [message metadata]} <response-channel]
-         (let [correlation-id (:correlation-id metadata)]
-           (when-let [return-channel (get @pending-calls correlation-id)]
-             (async/>! return-channel message)
-             (async/close! return-channel)
-             (swap! pending-calls dissoc correlation-id))))
+        [{:keys [message metadata]} <response-channel]
+        (let [correlation-id (:correlation-id metadata)]
+          (when-let [return-channel (get @pending-calls correlation-id)]
+            (async/>! return-channel message)
+            (async/close! return-channel)
+            (swap! pending-calls dissoc correlation-id))))
 
        ;; bookkeeping for sending the requests
        (kehaar.core/async=>rabbit >request-channel ch exchange queue-name)
        (kehaar.core/go-handler
-           [[return-channel message] channel]
-         (let [correlation-id (str (java.util.UUID/randomUUID))]
-           (swap! pending-calls assoc correlation-id return-channel)
-           (async/>! >request-channel {:message message
-                                       :metadata {:correlation-id correlation-id
-                                                  :reply-to response-queue
-                                                  :mandatory true}})
-           (async/go
-             (async/<! (async/timeout timeout))
-             (when-let [chan (get @pending-calls correlation-id)]
-               (async/close! chan)
-               (swap! pending-calls dissoc correlation-id))))))
+        [[return-channel message] channel]
+        (let [correlation-id (str (java.util.UUID/randomUUID))]
+          (swap! pending-calls assoc correlation-id return-channel)
+          (async/>! >request-channel {:message message
+                                      :metadata {:correlation-id correlation-id
+                                                 :reply-to response-queue
+                                                 :mandatory true}})
+          (async/go
+            (async/<! (async/timeout timeout))
+            (when-let [chan (get @pending-calls correlation-id)]
+              (async/close! chan)
+              (swap! pending-calls dissoc correlation-id))))))
      ch)))
 
 (defn external-service-fire-and-forget
@@ -222,68 +222,68 @@
        (kehaar.core/rabbit=>async ch response-queue <response-channel
                                   {:exclusive true} 1000)
        (kehaar.core/go-handler
-           [{:keys [message metadata]} <response-channel]
-         (let [correlation-id (:correlation-id metadata)]
-           (cond
-             (= :kehaar.core/stop message)
-             (when-let [return-channel (get-in @pending-calls [correlation-id :return-channel])]
-               (async/close! return-channel)
-               (swap! pending-calls dissoc correlation-id))
+        [{:keys [message metadata]} <response-channel]
+        (let [correlation-id (:correlation-id metadata)]
+          (cond
+            (= :kehaar.core/stop message)
+            (when-let [return-channel (get-in @pending-calls [correlation-id :return-channel])]
+              (async/close! return-channel)
+              (swap! pending-calls dissoc correlation-id))
 
-             (and (map? message)
-                  (:kehaar.core/inline message))
-             nil                         ; do nothing
+            (and (map? message)
+                 (:kehaar.core/inline message))
+            nil                         ; do nothing
 
-             (and (map? message)
-                  (:kehaar.core/response-queue message))
-             (if-let [return-channel (get-in @pending-calls [correlation-id :return-channel])]
-               (let [message-channel (async/chan 1 (map :message))
-                     response-queue (:kehaar.core/response-queue message)]
-                 (kehaar.core/rabbit=>async
-                  ch
-                  response-queue
-                  message-channel
-                  {:exclusive true}
-                  100
-                  true)
-                 (loop []
-                   (let [msg (async/<! message-channel)]
-                     (when (get-in @pending-calls [correlation-id :timeout])
-                       (swap! pending-calls update correlation-id dissoc :timeout))
-                     (if (nil? msg)
-                       (async/close! return-channel)
-                       (if (async/>! return-channel msg)
-                         (recur)
-                         (async/close! message-channel))))))
-               (do
-                 (log/info (format "Deleting queue %s" (:kehaar.core/response-queue message)))
-                 (langohr.queue/delete ch (:kehaar.core/response-queue message))))
+            (and (map? message)
+                 (:kehaar.core/response-queue message))
+            (if-let [return-channel (get-in @pending-calls [correlation-id :return-channel])]
+              (let [message-channel (async/chan 1 (map :message))
+                    response-queue (:kehaar.core/response-queue message)]
+                (kehaar.core/rabbit=>async
+                 ch
+                 response-queue
+                 message-channel
+                 {:exclusive true}
+                 100
+                 true)
+                (loop []
+                  (let [msg (async/<! message-channel)]
+                    (when (get-in @pending-calls [correlation-id :timeout])
+                      (swap! pending-calls update correlation-id dissoc :timeout))
+                    (if (nil? msg)
+                      (async/close! return-channel)
+                      (if (async/>! return-channel msg)
+                        (recur)
+                        (async/close! message-channel))))))
+              (do
+                (log/info (format "Deleting queue %s" (:kehaar.core/response-queue message)))
+                (langohr.queue/delete ch (:kehaar.core/response-queue message))))
 
-             :else
-             (when-let [return-channel (get-in @pending-calls [correlation-id :return-channel])]
-               (when (get-in @pending-calls [correlation-id :timeout])
-                 (swap! pending-calls update correlation-id dissoc :timeout))
-               (async/>! return-channel message)))))
+            :else
+            (when-let [return-channel (get-in @pending-calls [correlation-id :return-channel])]
+              (when (get-in @pending-calls [correlation-id :timeout])
+                (swap! pending-calls update correlation-id dissoc :timeout))
+              (async/>! return-channel message)))))
 
        ;; bookkeeping for sending the requests
        (kehaar.core/async=>rabbit >request-channel ch exchange queue-name)
        (kehaar.core/go-handler
-           [[return-channel message] channel]
-         (let [correlation-id (str (java.util.UUID/randomUUID))
-               timeout-ch (async/timeout timeout)]
-           (swap! pending-calls assoc correlation-id {:return-channel return-channel
-                                                      :timeout timeout-ch})
-           (async/>! >request-channel {:message message
-                                       :metadata {:correlation-id correlation-id
-                                                  :reply-to response-queue
-                                                  :mandatory true}})
+        [[return-channel message] channel]
+        (let [correlation-id (str (java.util.UUID/randomUUID))
+              timeout-ch (async/timeout timeout)]
+          (swap! pending-calls assoc correlation-id {:return-channel return-channel
+                                                     :timeout timeout-ch})
+          (async/>! >request-channel {:message message
+                                      :metadata {:correlation-id correlation-id
+                                                 :reply-to response-queue
+                                                 :mandatory true}})
 
-           (async/go
-             (async/<! timeout-ch)
-             (when (get-in @pending-calls [correlation-id :timeout])
-               (log/info "Streaming request timed out")
-               (async/close! (get-in @pending-calls [correlation-id :return-channel]))
-               (swap! pending-calls dissoc correlation-id))))))
+          (async/go
+            (async/<! timeout-ch)
+            (when (get-in @pending-calls [correlation-id :timeout])
+              (log/info "Streaming request timed out")
+              (async/close! (get-in @pending-calls [correlation-id :return-channel]))
+              (swap! pending-calls dissoc correlation-id))))))
      ch)))
 
 (defn async->fn


### PR DESCRIPTION
A job is a request from one service to another that can result in multiple responses from any number of services. It's important to note that while the number of responses and their source are not known by the service making the request, there is still a mechanism by which the system can tell when no further messages for a job will come from any service, at which point some resources are cleaned up.

See the README, and the jobs example project for a look at how it looks for users of the library.

*How it works:*

The underlying mechanism for requesting a job is very much like the one for making a request to another service for a single result: a message is placed on a queue that a service is listening on and the deserialized message is given to a function that produces responses. However, the message is more specialized. The metadata on the message does not include a `reply_to` channel, since responses are broadcast over a topic exchange. The message itself contains a "routing key" that is used by the requester to react to messages for jobs it cares about, and is used by the service doing the job if it needs to send work to further services that should be routed back to the original requesting service.

The service that requests jobs keeps a bit of state in a map that connects a routing key to the function to call when a message is heard for that routing key and to a count of the number of services working on that job. Every time a service working on the job "subcontracts" work out to another service, a message is sent on a special topic to increment that count. And when a service completes its work for a job, the requesting service decrements the count. Once the count reaches zero, the routing key is removed from the map.

![Work!](http://i.giphy.com/11Yh9WIh3ewk80.gif)

Some whitespace got mixed up in here... Please look at [the diff ignoring whitespace](https://github.com/democracyworks/kehaar/pull/28/files?w=1) to make sure you're not looking for changes that aren't changes.