### PR TITLE
Streaming improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,8 +98,10 @@ Some notes:
   deserialized as EDN. So expect any kind of serializable value,
   including `nil`.
 * If `:response` is `:streaming`, then `handler-function` should
-  return a sequence, which probably should be lazy. Each value in the
-  sequence will be returned to the client in order.
+  return a sequence, which probably should be lazy, or a core.async
+  channel, which must be closed when there are no more values. Each
+  value in the sequence or on the channel will be returned to the
+  client in order.
 * Incoming messages are nacked if the thread is taking too long to
   process the messages. This allows different instances of the service
   to process those messages.

--- a/docs/wire-up.md
+++ b/docs/wire-up.md
@@ -123,8 +123,8 @@ including `nil`.
 
 `streaming-handler-function` should be a function of a single
 argument, like `handler-function`, but should always return a sequence
-(lazy, if you like). Each value in the sequence will be returned to
-the client in order.
+(lazy, if you like) or a core.async channel. Each value in the
+sequence or on the channel will be returned to the client in order.
 
 `wire-up/start-responder!` and `wire-up/start-streaming-responder!`
 all take an extra optional argument for the number of threads to take

--- a/docs/wire-up.md
+++ b/docs/wire-up.md
@@ -124,7 +124,9 @@ including `nil`.
 `streaming-handler-function` should be a function of a single
 argument, like `handler-function`, but should always return a sequence
 (lazy, if you like) or a core.async channel. Each value in the
-sequence or on the channel will be returned to the client in order.
+sequence or on the channel will be returned to the client in
+order. When returning a core.async channel, you must close the channel
+when there are no more values.
 
 `wire-up/start-responder!` and `wire-up/start-streaming-responder!`
 all take an extra optional argument for the number of threads to take

--- a/example/src/kehaar_example/streaming/producer.clj
+++ b/example/src/kehaar_example/streaming/producer.clj
@@ -1,15 +1,22 @@
 (ns kehaar-example.streaming.producer
   (:require [kehaar.rabbitmq :as kehaar-rabbit]
             [kehaar.configured :as configured]
-            [clojure.tools.logging :as log]))
+            [clojure.tools.logging :as log]
+            [clojure.core.async :as async]))
 
-(defn countdown [{:keys [num delay]}]
+(defn countdown [{:keys [num delay] :or {delay 0}}]
   (log/info "Counting down from" num)
-  (when (>= num 0)
-    (lazy-seq
-     (Thread/sleep (or delay 0))
-     (cons num (countdown {:num (dec num)
-                           :delay delay})))))
+  (let [c (async/chan 10)]
+    (async/go-loop [n num]
+      (log/info "Counting down from" n)
+      (if (> 0 n)
+        (async/close! c)
+        (do
+          (async/<! (async/timeout delay))
+          (async/>! c {:num n
+                       :delay delay})
+          (recur (dec n)))))
+    c))
 
 (defn -main [& args]
   (log/info "Producer starting up...")
@@ -22,5 +29,4 @@
         :f 'kehaar-example.streaming.producer/countdown
         :threshold 5}]}))
   (log/info "Producer ready!")
-  (loop []
-    (recur)))
+  (.join (Thread/currentThread)))

--- a/src/kehaar/configured.clj
+++ b/src/kehaar/configured.clj
@@ -67,22 +67,23 @@
   * `incoming-service-options`: A map defining the service
 
   Valid keys for the `incoming-service-options` are:
-  * `:f`: A fully qualified symbol for the function that will be called
-  for every message received on the queue. It must be a function of
-  one argument, which will be a serializable Clojure value. For
-  `:streaming` responses, it must return a sequence. For `:streaming`
-  or `true` responses, it must return a serializable Clojure
-  value. (required)
+  * `:f`: A fully qualified symbol for the function that will be
+  called for every message received on the queue. It must be a
+  function of one argument, which will be a serializable Clojure
+  value. For `:streaming` responses, it must return a sequence with
+  the values to stream, or a core.async channel to stream values
+  from. For `:streaming` or `true` responses, values must be
+  serializable Clojure values. (required)
   * `:queue`: The name of the queue to listen for requests on. (required)
   * `:queue-options`: The options map passed to `langohr.queue/declare`
   for the queue. (optional, default {:auto-delete false :durable true
   :exclusive false})
   * `:response`: How to respond. Key should be `nil`, `:streaming` or
   `true`. `nil` means don't return the result of the function to the
-  caller. `:streaming` means the function will return a sequence, the
-  values of which will be returned to the caller one by one. `true`
-  means return the result of the function in one message back to the
-  caller. (optional, default `nil`)
+  caller. `:streaming` means the function will return a sequence or a
+  core.async channel, the values from which will be returned to the
+  caller one by one. `true` means return the result of the function in
+  one message back to the caller. (optional, default `nil`)
   * `:exchange`: The name of the exchange. (optional, default `\"\"`)
   * `:prefetch-limit`: The number of messages to prefetch from the
   queue. (optional, default 1).

--- a/src/kehaar/configured.clj
+++ b/src/kehaar/configured.clj
@@ -72,8 +72,9 @@
   function of one argument, which will be a serializable Clojure
   value. For `:streaming` responses, it must return a sequence with
   the values to stream, or a core.async channel to stream values
-  from. For `:streaming` or `true` responses, values must be
-  serializable Clojure values. (required)
+  from. When returning a core.async channel, you must close the
+  channel when there are no more values. For `:streaming` or `true`
+  responses, values must be serializable Clojure values. (required)
   * `:queue`: The name of the queue to listen for requests on. (required)
   * `:queue-options`: The options map passed to `langohr.queue/declare`
   for the queue. (optional, default {:auto-delete false :durable true


### PR DESCRIPTION
# A better stream

![a really good stream](http://i.giphy.com/l3qZRW4LBHcQw.gif)

## A smarter threshold

Before, to decide whether or not to use a bespoke queue for a streaming response, the code would check the response collection to see if it had at least as many elements as the `threshold`. If it was smaller, responses would go out on the shared response queue. If it had at least that many, responses would go out on a bespoke queue. However, the time to realize that many elements could take longer than the `timeout`, resulting in a timeout response even though the time between any two elements wouldn't be greater than the timeout.

With these changes, the elements before the `threshold` will be sent on the shared response queue, switching over to a bespoke queue once the number of elements sent so far reaches the threshold number.

## Using core.async channels when producing streams

Previously, a streaming responder needed to return a sequence of its results to be streamed. However, using a core.async channel could be more idiomatic for producing results.

Now, a streaming responder can return a core.async channel and its values will be streamed. The channel must be closed when there will be no more results.