### PR TITLE
Recovery of long lived server-named queues

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,6 +6,7 @@
   :dependencies [[org.clojure/clojure "1.7.0"]
                  [org.clojure/core.async "0.2.385"]
                  [com.novemberain/langohr "3.2.0"]
+                 [org.apache.commons/commons-collections4 "4.1"]
                  [org.clojure/tools.logging "0.3.1"]]
   :test-selectors {:default (complement :rabbit-mq)
                    :rabbit-mq :rabbit-mq

--- a/src/kehaar/response_queues.clj
+++ b/src/kehaar/response_queues.clj
@@ -1,0 +1,47 @@
+(ns kehaar.response-queues
+  (import [org.apache.commons.collections4.bidimap TreeBidiMap]
+          [clojure.lang Associative ILookup IMapEntry]))
+
+(defprotocol IReverseLookup
+  (get-key [this val]))
+
+(deftype ResponseQueueMap [^TreeBidiMap tree-bidi-map]
+  Associative
+  (containsKey [_ k]
+    (.containsKey tree-bidi-map k))
+
+  (entryAt [_ k]
+    (if (.containsKey tree-bidi-map k)
+      (reify IMapEntry
+        (key [_] k)
+        (val [_] (.get tree-bidi-map k)))))
+
+  (assoc [this k v]
+    (.put tree-bidi-map k v)
+    this)
+
+  ILookup
+  (valAt [_ k]
+    (.get tree-bidi-map k))
+
+  (valAt [_ k not-found]
+    (or (.get tree-bidi-map k)
+        not-found))
+
+  IReverseLookup
+  (get-key [_ v]
+    (.getKey tree-bidi-map v)))
+
+(defn response-queue-map []
+  (->ResponseQueueMap (TreeBidiMap.)))
+
+(defonce response-queues (atom (response-queue-map)))
+
+(defn set-response-queue! [queue response-queue]
+  (swap! response-queues assoc queue response-queue))
+
+(defn get-queue [response-queue]
+  (get-key @response-queues response-queue))
+
+(defn get-response-queue [queue]
+  (get @response-queues queue))


### PR DESCRIPTION
# Recovery

Server-named queues set up by kehaar for use with responders need to be tracked so that kehaar can set the correct reply-to queue for requests when those queues get renamed during a Rabbit recovery from a failure state.

This keeps track of a mapping from an external service queue name to the name of the server-named queue for responses. State is kept in an atom holding a bidirectional map, and convenience functions are provided for interacting with it.

When Rabbit renames a server-nemed queue, a callback updates the state if necessary.

Short-lived server-named queues are not tracked. You better believe that a service will time out waiting for an answer before Rabbit can recover. It is not fast.

This recovery only happens for clients using the `kehaar.configured/init!` function.

## Examples from logs

### Example project

```
... The example project in a failure state ...
INFO: Requesting fib: 47
May 02, 2017 1:55:01 PM kehaar.core invoke
SEVERE: Kehaar: caught an exception in go-handler: channel
com.rabbitmq.client.AlreadyClosedException: connection is already closed due to connection error; cause: java.net.SocketException: Connection reset
at com.rabbitmq.client.impl.AMQChannel.ensureIsOpen (AMQChannel.java:195)
at com.rabbitmq.client.impl.AMQChannel.transmit (AMQChannel.java:296)
at com.rabbitmq.client.impl.ChannelN.basicPublish (ChannelN.java:648)
at com.rabbitmq.client.impl.recovery.AutorecoveringChannel.basicPublish (AutorecoveringChannel.java:168)
at langohr.basic$publish.invoke (basic.clj:114)
at kehaar.core$async_EQ__GT_rabbit$fn__8259$state_machine__6193__auto____8260$fn__8262.invoke (core.clj:118)
at kehaar.core$async_EQ__GT_rabbit$fn__8259$state_machine__6193__auto____8260.invoke (core.clj:118)
at clojure.core.async.impl.ioc_macros$run_state_machine.invoke (ioc_macros.clj:1012)
at clojure.core.async.impl.ioc_macros$run_state_machine_wrapped.invoke (ioc_macros.clj:1016)
at clojure.core.async.impl.ioc_macros$take_BANG_$fn__6209.invoke (ioc_macros.clj:1025)
at clojure.core.async.impl.channels.ManyToManyChannel$fn__1128$fn__1129.invoke (channels.clj:95)
at clojure.lang.AFn.run (AFn.java:22)
at java.util.concurrent.ThreadPoolExecutor.runWorker (ThreadPoolExecutor.java:1142)
at java.util.concurrent.ThreadPoolExecutor$Worker.run (ThreadPoolExecutor.java:617)
at java.lang.Thread.run (Thread.java:745)

May 02, 2017 1:55:01 PM kehaar.configured invoke
INFO: RabbitMQ connection recovery. Renamed response queue for countdown from amq.gen-V5woKGAEPf3xuH_4TJzRYA to amq.gen-ZsKkmu1CvMnfRXCsC0M8tA
May 02, 2017 1:55:01 PM kehaar-example.core invoke
INFO: Got fib: 38 Result: nil
May 02, 2017 1:55:01 PM kehaar-example.core invoke
INFO: Requesting fib: 48
May 02, 2017 1:55:01 PM kehaar-example.core invoke
INFO: Received event: 7778742049
May 02, 2017 1:55:02 PM kehaar-example.core invoke
INFO: Got fib: 48 Result: 7778742049
... the example project has recovered ...
```

### Streaming example project

```
... The streaming consumer in a failure state ...
May 02, 2017 3:11:45 PM kehaar.wire-up invoke
INFO: Streaming request timed out
May 02, 2017 3:11:49 PM kehaar-example.streaming.consumer invoke
INFO: Consumer making a request!
May 02, 2017 3:11:49 PM kehaar.core invoke
SEVERE: Kehaar: caught an exception in go-handler: channel
com.rabbitmq.client.AlreadyClosedException: connection is already closed due to connection error; protocol method: #method<connection.close>(reply-code=320, reply-text=CONNECTION_FORCED - broker forced connection closure with reason 'shutdown', class-id=0, method-id=0)
at com.rabbitmq.client.impl.AMQChannel.ensureIsOpen (AMQChannel.java:195)
at com.rabbitmq.client.impl.AMQChannel.transmit (AMQChannel.java:296)
at com.rabbitmq.client.impl.ChannelN.basicPublish (ChannelN.java:648)
at com.rabbitmq.client.impl.recovery.AutorecoveringChannel.basicPublish (AutorecoveringChannel.java:168)
at langohr.basic$publish.invoke (basic.clj:114)
at kehaar.core$async_EQ__GT_rabbit$fn__8265$state_machine__6199__auto____8266$fn__8268.invoke (core.clj:118)
at kehaar.core$async_EQ__GT_rabbit$fn__8265$state_machine__6199__auto____8266.invoke (core.clj:118)
at clojure.core.async.impl.ioc_macros$run_state_machine.invoke (ioc_macros.clj:1012)
at clojure.core.async.impl.ioc_macros$run_state_machine_wrapped.invoke (ioc_macros.clj:1016)
at clojure.core.async.impl.ioc_macros$take_BANG_$fn__6215.invoke (ioc_macros.clj:1025)
at clojure.core.async.impl.channels.ManyToManyChannel$fn__1134$fn__1135.invoke (channels.clj:95)
at clojure.lang.AFn.run (AFn.java:22)
at java.util.concurrent.ThreadPoolExecutor.runWorker (ThreadPoolExecutor.java:1142)
at java.util.concurrent.ThreadPoolExecutor$Worker.run (ThreadPoolExecutor.java:617)
at java.lang.Thread.run (Thread.java:745)

May 02, 2017 3:11:49 PM kehaar.wire-up invoke
INFO: Streaming request timed out
May 02, 2017 3:11:52 PM kehaar.configured invoke
INFO: RabbitMQ connection recovery. Renamed response queue for countdown from amq.gen-xBTZKs6OifnrEdwQmGT1qA to amq.gen-xE6KaL9hpbGwCTYU6zqiVQ
May 02, 2017 3:11:54 PM kehaar-example.streaming.consumer invoke
INFO: Consumer making a request!
May 02, 2017 3:11:54 PM kehaar.wire-up invoke
INFO: Streaming request timed out
May 02, 2017 3:11:59 PM kehaar-example.streaming.consumer invoke
INFO: Consumer making a request!
May 02, 2017 3:11:59 PM kehaar.wire-up invoke
INFO: Streaming request timed out
May 02, 2017 3:12:03 PM kehaar-example.streaming.consumer invoke
INFO: Got {:num 10, :delay 4000}
May 02, 2017 3:12:07 PM kehaar-example.streaming.consumer invoke
INFO: Got {:num 9, :delay 4000}
May 02, 2017 3:12:11 PM kehaar-example.streaming.consumer invoke
INFO: Got {:num 8, :delay 4000}
... The streaming consumer has recovered ...
```

![RabbitMQ recovery](https://media.giphy.com/media/vL3mgyhQWkggw/giphy.gif)