### PR TITLE
More connect retries

### DIFF
--- a/test/kehaar/rabbit_mq_test.clj
+++ b/test/kehaar/rabbit_mq_test.clj
@@ -30,7 +30,7 @@
     (async=>rabbit chan ch rabbit-queue)
     (rabbit=>async ch rabbit-queue response-chan)
     (bounded>!! chan {:message message
-                     :metadata {}} 100)
+                      :metadata {}} 100)
     (is (= message (:message (bounded<!! response-chan 500))))
     (Thread/sleep 500) ; wait for ack before closing channel
     (rmq/close ch)

--- a/test/kehaar/wire_up_test.clj
+++ b/test/kehaar/wire_up_test.clj
@@ -169,7 +169,9 @@
           response-fn (async->fn c)
           message {:test true}
           response-channel (response-fn message)]
-      (is (= [response-channel message] (async/<!! c)))))
+      (is (= [response-channel message] (async/<!! c))))))
+
+(deftest ^:rabbit-mq async->fn-rmq-test
   (testing "response is nil when no response to service past timeout"
     (let [timeout   2000
           conn      (rmq/connect rmq-config)


### PR DESCRIPTION
While trying to diagnose krakenstein flakiness on Marla's machine, we saw several components fall over due to `java.util.concurrent.Timeout` exceptions being thrown and not retried. It seemed like this was exactly the kind of thing `connect-with-retries` was intended to make more robust. Hence this PR.

This should help krakenstein come up more often without manual intervention.

When I went to run the tests after adding this, I found a broker-requiring test that had snuck into a `deftest` form without the `^:rabbit-mq` metadata set on it. So I also fixed that.