### PR TITLE
Update deps to latest versions we want

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,9 +3,9 @@
   :description "Kehaar passes messages to and from RabbitMQ channels"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.7.0"]
-                 [org.clojure/core.async "0.2.385"]
-                 [com.novemberain/langohr "3.2.0"]
+  :dependencies [[org.clojure/clojure "1.8.0"]
+                 [org.clojure/core.async "0.3.443"]
+                 [com.novemberain/langohr "3.7.0"]
                  [org.apache.commons/commons-collections4 "4.1"]
                  [org.clojure/tools.logging "0.3.1"]]
   :test-selectors {:default (complement :rabbit-mq)


### PR DESCRIPTION
This is primarily motivated by bringing in a version of core.async that passes clojure 1.9.0-alpha17's specs.

I had a project not compiling under 1.9.0-alpha17 because it pulled in kehaar but not core.async.

OK if I update the changelog and example project and push a 0.10.5 release with these updates?