### PR TITLE
Use safer EDN encoding and reading

### DIFF
--- a/src/kehaar/core.clj
+++ b/src/kehaar/core.clj
@@ -1,11 +1,11 @@
 (ns kehaar.core
   (:require [clojure.core.async :as async]
-            [clojure.edn :as edn]
             [langohr.basic :as lb]
             [langohr.consumers :as lc]
             [langohr.queue :as lq]
             [clojure.tools.logging :as log]
-            [kehaar.async :refer [bounded>!!]]))
+            [kehaar.async :refer [bounded>!!]]
+            [kehaar.edn :as edn]))
 
 (defn read-payload
   "Unsafely read a byte array as edn."
@@ -116,7 +116,7 @@
    (async=>rabbit channel rabbit-channel "" queue))
   ([channel rabbit-channel exchange queue]
    (go-handler [{:keys [message metadata]} channel]
-     (lb/publish rabbit-channel exchange queue (pr-str message)
+     (lb/publish rabbit-channel exchange queue (edn/pr-str message)
                  metadata))))
 
 (defn async=>rabbit-with-reply-to
@@ -138,12 +138,12 @@
   ([channel rabbit-channel exchange ignore-no-reply-to]
    (go-handler [{:keys [message metadata]} channel]
      (if-let [reply-to (:reply-to metadata)]
-       (lb/publish rabbit-channel exchange reply-to (pr-str message)
+       (lb/publish rabbit-channel exchange reply-to (edn/pr-str message)
                    (assoc metadata :mandatory true))
        (when-not ignore-no-reply-to
          (log/warn "Kehaar: No reply-to in metadata."
-                   (pr-str message)
-                   (pr-str metadata)))))))
+                   (edn/pr-str message)
+                   (edn/pr-str metadata)))))))
 
 (defn thread-handler
   [channel f threads]
@@ -232,7 +232,7 @@
                                    (reset! stream-active? false)))
                 put-fn (fn [v]
                          (when @stream-active?
-                           (lb/publish ch "" response-queue (pr-str v)
+                           (lb/publish ch "" response-queue (edn/pr-str v)
                                        (assoc metadata :mandatory true))))]
             ;; add return listener
             (.addReturnListener ch return-listener)

--- a/src/kehaar/edn.clj
+++ b/src/kehaar/edn.clj
@@ -1,0 +1,32 @@
+(ns kehaar.edn
+  (:require
+   [clojure.edn :as edn]
+   [clojure.walk :as walk])
+  (:import (java.util.regex Pattern))
+  (:refer-clojure :exclude [pr-str read-string]))
+
+(defn sanitize
+  "Replaces regexes in value `v` with their string representation so that `v`
+  can be EDN encoded. This would be unnecessary if _someone_ had done their
+  job:
+  https://github.com/clojure/clojure/blob/c6756a8bab137128c8119add29a25b0a88509900/src/jvm/clojure/lang/EdnReader.java#L53"
+  [v]
+  (walk/postwalk
+   (fn [f]
+     (if (instance? Pattern f)
+       (.toString f)
+       f))
+   v))
+
+(defn pr-str
+  "A safer replacement for clojure.core/pr-str that replaces
+  java.util.regex.Pattern instances with their string representations. See
+  `kehaar.edn/sanitize` for why this is necessary."
+  [v]
+  (clojure.core/pr-str (sanitize v)))
+
+(defn read-string
+  "A safer replacement for clojure.edn/read-string that doesn't throw
+  exceptions on unknown tags. Instead it just reads in their values as is."
+  [s]
+  (edn/read-string {:default (fn [_ v] v)} s))

--- a/src/kehaar/jobs.clj
+++ b/src/kehaar/jobs.clj
@@ -1,6 +1,7 @@
 (ns kehaar.jobs
   (:require [clojure.core.async :as async]
-            [langohr.basic :as lb]))
+            [langohr.basic :as lb]
+            [kehaar.edn :as edn]))
 
 (def ^:const kehaar-exchange "kehaar")
 
@@ -51,14 +52,14 @@
         (lb/publish rabbit-ch
                     exchange
                     routing-key
-                    (pr-str {::message ::complete
-                             ::routing-key routing-key})
+                    (edn/pr-str {::message ::complete
+                                 ::routing-key routing-key})
                     {})
         (do
           (lb/publish rabbit-ch
                       exchange
                       routing-key
-                      (pr-str message)
+                      (edn/pr-str message)
                       metadata)
           (recur))))))
 

--- a/test/kehaar/core_test.clj
+++ b/test/kehaar/core_test.clj
@@ -2,13 +2,14 @@
   (:require [clojure.test :refer :all]
             [kehaar.core :refer :all]
             [clojure.core.async :as async]
-            [kehaar.async :refer [bounded<!! bounded>!!]]))
+            [kehaar.async :refer [bounded<!! bounded>!!]]
+            [kehaar.edn :as edn]))
 
 (defn edn-bytes
   "Returns a byte array of the edn representation of x."
   [x]
   (->> x
-       pr-str
+       edn/pr-str
        (map int)
        byte-array))
 

--- a/test/kehaar/edn_test.clj
+++ b/test/kehaar/edn_test.clj
@@ -1,0 +1,34 @@
+(ns kehaar.edn-test
+  (:require
+   [clojure.test :refer :all]
+   [kehaar.edn :refer :all])
+  (:refer-clojure :exclude [pr-str read-string]))
+
+(deftest sanitize-test
+  (testing "replaces all nested regexen with string representations"
+    (is (= {:foo {:bar "re0" :baz "stringy"}
+            :qux #{"re1" [:hi "re2"]}
+            :quux {:quuz "re3" :corge {"grault" "re4"}}}
+           (sanitize {:foo {:bar #"re0" :baz "stringy"}
+                      :qux #{#"re1" [:hi #"re2"]}
+                      :quux {:quuz #"re3" :corge {"grault" #"re4"}}})))))
+
+(deftest pr-str-test
+  (testing "generates valid EDN from data structures containing regexen"
+    (let [input {:foo {:bar #"re0" :baz "stringy"}
+                 :qux #{#"re1" [:hi #"re2"]}
+                 :quux {:quuz #"re3" :corge {"grault" #"re4"}}}
+          expected {:foo {:bar "re0" :baz "stringy"}
+                    :qux #{"re1" [:hi "re2"]}
+                    :quux {:quuz "re3" :corge {"grault" "re4"}}}]
+      (is (= expected
+             (-> input
+                 pr-str
+                 read-string))))))
+
+(deftest read-string-test
+  (testing "handles unknown tags by just dropping their values into result"
+    (let [input "#{#foo \"tagged foo\" #bar {:guess \"I'm a map\"} #qux [1 2 3]}"
+          expected #{"tagged foo" {:guess "I'm a map"} [1 2 3]}]
+      (is (= expected
+             (read-string input))))))


### PR DESCRIPTION
Adds new pr-str and read-string drop-in replacements that sanitize encoded values of regexen before encoding them into EDN strings and doesn't throw exceptions on unknow tags, respectively. Uses them throughout kehaar.