### PR TITLE
Allow real values in configured where symbols go

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,15 @@ is a collection of all the shutdownable resources created in the
 process, and it may be passed to `kehaar.configured/shutdown!` to
 clean them all up.
 
+##### Specifying funtions and channels
+
+Anywhere a `kehaar.configured` initialzation function expects a
+function or channel, you may pass instead a fully qualified symbol
+naming the function or channel you wish to use. If you do, the
+appropriate namespace will be required and the function or channel
+value will be used. This is useful, for example, if you wish to keep
+your configuration in an edn file.
+
 #### Examples
 
 > All examples are exercised by the example project. See
@@ -60,7 +69,7 @@ You'll need to declare it.
 (kehaar.configured/init-external-service!
  connection
  {:queue "service-works.service.process"
-  :channel 'fully.qualified/process-channel})
+  :channel process-channel})
 ```
 
 Then you can create a function that "calls" that service, like so:
@@ -88,7 +97,7 @@ Some notes:
 (kehaar.configured/init-incoming-service!
  connection
  {:queue "service-works.service.process"
-  :f 'fully.qualified/handler-function})
+  :f handler-function})
 ```
 
 Some notes:
@@ -114,7 +123,7 @@ Some notes:
 ```clojure
 (kehaar.configured/init-outgoing-job!
  connection
- {:jobs-chan 'fully.qualified/job-request-channel
+ {:jobs-chan job-request-channel
   :queue "service.works.service.perform-job"})
 ```
 
@@ -136,7 +145,7 @@ job, but you are unlikely to need it.
 (kehaar.configured/init-incoming-job!
  connection
  {:queue "service.works.service.perform-job"
-  :f 'fully.qualified/handler-function})
+  :f handler-function})
 ```
 
 Some notes:
@@ -152,7 +161,7 @@ Some notes:
 ```clojure
 (kehaar.configured/init-outgoing-job!
  connection
- {:jobs-chan 'fully.qualified/subcontract-channel
+ {:jobs-chan subcontract-channel
   :queue "service.works.service.subcontract-part-of-job"})
 ```
 
@@ -174,7 +183,7 @@ current job, and the message to send.
  {:queue "my-service.events.create-something"
   :exchange "events"
   :routing-key "create-something"
-  :f 'fully.qualified/handler-function})
+  :f handler-function})
 ```
 
 Some notes:
@@ -190,7 +199,7 @@ Some notes:
  connection
  {:exchange "events"
   :routing-key "create-something"
-  :channel 'fully.qualified/created-event-channel})
+  :channel created-event-channel})
 ```
 
 The event messages you send on the channel must be EDN-izable.

--- a/example/project.clj
+++ b/example/project.clj
@@ -4,7 +4,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [democracyworks/kehaar "0.11.0"]]
+                 [democracyworks/kehaar "0.11.1-SNAPSHOT"]]
   :main kehaar-example.core
   :aliases {"streaming-producer" ["run" "-m" "kehaar-example.streaming.producer"]
             "streaming-consumer" ["run" "-m" "kehaar-example.streaming.consumer"]

--- a/example/src/kehaar_example/jobs/counter.clj
+++ b/example/src/kehaar_example/jobs/counter.clj
@@ -23,9 +23,9 @@
   (async/close! out-chan))
 
 (def config
-  {:incoming-jobs [{:f 'kehaar-example.jobs.counter/job-handler
+  {:incoming-jobs [{:f job-handler
                     :queue "counting-job"}]
-   :outgoing-jobs [{:jobs-chan 'kehaar-example.jobs.counter/three-subjob
+   :outgoing-jobs [{:jobs-chan three-subjob
                     :queue "do-fizz"}]})
 
 (defn setup []

--- a/example/src/kehaar_example/jobs/instigator.clj
+++ b/example/src/kehaar_example/jobs/instigator.clj
@@ -15,7 +15,7 @@
   (jobs/async->job job-request-chan))
 
 (def config
-  {:outgoing-jobs [{:jobs-chan 'kehaar-example.jobs.instigator/job-request-chan
+  {:outgoing-jobs [{:jobs-chan job-request-chan
                     :queue "counting-job"}]})
 
 (defn make-job-handler [id n]

--- a/example/src/kehaar_example/jobs/threes.clj
+++ b/example/src/kehaar_example/jobs/threes.clj
@@ -13,7 +13,7 @@
   (async/close! out-chan))
 
 (def config
-  {:incoming-jobs [{:f 'kehaar-example.jobs.threes/job-handler
+  {:incoming-jobs [{:f job-handler
                     :queue "do-fizz"}]})
 
 (defn setup []

--- a/example/src/kehaar_example/streaming/consumer.clj
+++ b/example/src/kehaar_example/streaming/consumer.clj
@@ -17,7 +17,7 @@
       [{:response :streaming
         :queue "countdown"
         :timeout 5000
-        :channel 'kehaar-example.streaming.consumer/get-countdown-ch}]}))
+        :channel get-countdown-ch}]}))
 
   (log/info "Consumer making a request!")
   (doseq [n [10 10 3 3 10]]

--- a/example/src/kehaar_example/streaming/producer.clj
+++ b/example/src/kehaar_example/streaming/producer.clj
@@ -26,7 +26,7 @@
      {:incoming-services
       [{:response :streaming
         :queue "countdown"
-        :f 'kehaar-example.streaming.producer/countdown
+        :f countdown
         :threshold 5}]}))
   (log/info "Producer ready!")
   (.join (Thread/currentThread)))


### PR DESCRIPTION
Anywhere a `kehaar.configured` initialzation function used to take a symbol that named a function or channel can now take the actual function or channel itself.