### PR TITLE
Update Langohr to 4.1.0

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## Changes between Kehaar 0.11.1 and HEAD
+
+Updated Langohr to 4.1.0
+
 ## Changes between Kehaar 0.11.0 and 0.11.1
 
 Initialization functions in `kehaar.configured` can now also take

--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.clojure/core.async "0.3.443"]
-                 [com.novemberain/langohr "3.7.0"]
+                 [com.novemberain/langohr "4.1.0"]
                  [org.apache.commons/commons-collections4 "4.1"]
                  [org.clojure/tools.logging "0.3.1"]]
   :test-selectors {:default (complement :rabbit-mq)


### PR DESCRIPTION
A wholly transparent upgrade.