### PR TITLE
Add blank config param helper fn

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,9 +2,24 @@
 
 ## Changes between Kehaar 0.11.4 and HEAD
 
-Kehaar will output additional helpful information if an exception is thrown
-while trying to realize a symbol from a kehaar.configured handler fn name.
-Specifically it will tell you the name of the symbol it was trying to realize.
+- The `kehaar.rabbitmq` namespace has a new fn named
+  `dissoc-blank-config-params-with-defaults`. This is an optional helper fn
+  whose purpose is to assist with not clobbering default values with emtpy
+  strings and nils in your RabbitMQ connection config map (i.e. the arg you'll
+  pass to `connect-with-retries`). It dissoc's any value for the following
+  keys:
+    - :username
+    - :hostname
+    - :vhost
+    - :host
+    - :port
+    - :requested-heartbeat
+  ...where that value is either nil or a string for which
+  `clojure.string/blank?` returns true.
+
+- Kehaar will output additional helpful information if an exception is thrown
+  while trying to realize a symbol from a kehaar.configured handler fn name.
+  Specifically it will tell you the name of the symbol it was trying to realize.
 
 ## Changes between Kehaar 0.11.3 and 0.11.4
 

--- a/project.clj
+++ b/project.clj
@@ -3,11 +3,11 @@
   :description "Kehaar passes messages to and from RabbitMQ channels"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.8.0"]
-                 [org.clojure/core.async "0.3.443"]
+  :dependencies [[org.clojure/clojure "1.9.0" :scope "provided"]
+                 [org.clojure/core.async "0.4.474" :scope "provided"]
                  [com.novemberain/langohr "4.1.0"]
-                 [org.apache.commons/commons-collections4 "4.1"]
-                 [org.clojure/tools.logging "0.3.1"]]
+                 [org.apache.commons/commons-collections4 "4.2"]
+                 [org.clojure/tools.logging "0.4.1"]]
   :test-selectors {:default (complement :rabbit-mq)
                    :rabbit-mq :rabbit-mq
                    :all (constantly true)}

--- a/src/kehaar/rabbitmq.clj
+++ b/src/kehaar/rabbitmq.clj
@@ -1,6 +1,23 @@
 (ns kehaar.rabbitmq
   (:require [langohr.core :refer [connect]]
+            [clojure.string :as str]
             [clojure.tools.logging :as log]))
+
+(defn dissoc-blank-config-params-with-defaults
+  "Takes a langohr RabbitMQ connection config map and returns a new one with
+  all blank params with known-sane defaults dissoc'ed. This will allow the
+  default to take over rather than using an invalid config."
+  [config]
+  (let [params-with-defaults #{:username :password :vhost :host :port
+                               :requested-heartbeat}]
+    (reduce-kv (fn [c k v]
+                 (if (and (params-with-defaults k)
+                          (if (string? v)
+                            (str/blank? v)
+                            (nil? v)))
+                   (dissoc c k)
+                   c))
+               config config)))
 
 (defn connect-with-retries
   "Attempts to connect to RabbitMQ broker `tries` times.

--- a/src/kehaar/rabbitmq.clj
+++ b/src/kehaar/rabbitmq.clj
@@ -9,7 +9,8 @@
   default to take over rather than using an invalid config."
   [config]
   (let [params-with-defaults #{:username :password :vhost :host :port
-                               :requested-heartbeat}]
+                               :requested-heartbeat :requested-channel-max
+                               :connection-timeout :automatically-recover}]
     (reduce-kv (fn [c k v]
                  (if (and (params-with-defaults k)
                           (if (string? v)

--- a/test/kehaar/rabbitmq.clj
+++ b/test/kehaar/rabbitmq.clj
@@ -1,0 +1,19 @@
+(ns kehaar.rabbitmq
+  (:require [clojure.test :refer :all]
+            [kehaar.rabbitmq :refer :all]))
+
+(deftest dissoc-blank-config-params-with-defaults-test
+  (testing "leaves non-known-good-default nil / blank params alone"
+    (is (= {:p1 "", :p2 nil}
+           (dissoc-blank-config-params-with-defaults {:p1 "", :p2 nil}))))
+  (testing "handles non-string values"
+    (is (= {:p1 123}
+           (dissoc-blank-config-params-with-defaults {:p1 123}))))
+  (testing "dissoc's nil values with known-good defaults"
+    (is (= {:p2 nil}
+           (dissoc-blank-config-params-with-defaults
+            {:username nil, :p2 nil}))))
+  (testing "dissoc's blank string values with known-good defaults"
+    (is (= {:p2 nil}
+           (dissoc-blank-config-params-with-defaults
+            {:host "", :p2 nil})))))

--- a/test/kehaar/rabbitmq_test.clj
+++ b/test/kehaar/rabbitmq_test.clj
@@ -1,4 +1,4 @@
-(ns kehaar.rabbitmq
+(ns kehaar.rabbitmq-test
   (:require [clojure.test :refer :all]
             [kehaar.rabbitmq :refer :all]))
 


### PR DESCRIPTION
Hopefully the changelog addition explains the _what_. As for the _why_, we ran into a need for something like this with components that connect to CloudAMQP in one env but to our (very default-y) RabbitMQ clusters in another.