### PR TITLE
Debug handlers

### DIFF
--- a/src/kehaar/configured.clj
+++ b/src/kehaar/configured.clj
@@ -51,7 +51,11 @@
                   {:symbol x, :cause e}))))
     x))
 
-(defn realize-fn [x] (realize-symbol-or-self x (not debug-handlers?)))
+(defn realize-fn
+  ([x] (realize-fn x debug-handlers?))
+  ([x debug?]
+   (realize-symbol-or-self x (not debug?))))
+
 (defn realize-chan [x] (realize-symbol-or-self x true))
 
 (defn init-exchange!

--- a/src/kehaar/configured.clj
+++ b/src/kehaar/configured.clj
@@ -37,8 +37,9 @@
   if `resolve?` is true, returns the value in the var;
   otherwise, returns the var itself.
 
-  ((realize-symbol-or-self 'clojure.core/inc) 4) ;;=> 5
-  ((realize-symbol-or-self inc) 5)               ;;=> 6"
+  ((realize-symbol-or-self 'clojure.core/inc) 4)   ;;=> 5
+  ((realize-symbol-or-self inc) 5)                 ;;=> 6
+  (realize-symbol-or-self 'clojure.core/inc false) ;;=> #'clojure.core/inc"
   ([x] (realize-symbol-or-self x true))
   ([x resolve?]
    (if (symbol? x)

--- a/src/kehaar/configured.clj
+++ b/src/kehaar/configured.clj
@@ -43,11 +43,14 @@
   (if (symbol? x)
     (try
       (require-ns x)
-      (cond-> (find-var x)
-        resolve? var-get)
+      (if-let [v (find-var x)]
+        (if resolve?
+          (var-get v)
+          v)
+        (throw (ex-info (str "#'" (pr-str x) " does not exist") {})))
       (catch Exception e
         (throw
-         (ex-info (str "ERROR while trying realize symbol" (pr-str x))
+         (ex-info (str "ERROR while trying realize symbol " (pr-str x))
                   {:symbol x, :cause e}))))
     x))
 

--- a/src/kehaar/configured.clj
+++ b/src/kehaar/configured.clj
@@ -60,7 +60,7 @@
   ([x debug?]
    (realize-symbol-or-self x (not debug?))))
 
-(defn realize-chan [x] (realize-symbol-or-self x true))
+(def realize-chan realize-symbol-or-self)
 
 (defn init-exchange!
   "Initializes an exchange.

--- a/src/kehaar/configured.clj
+++ b/src/kehaar/configured.clj
@@ -24,23 +24,27 @@
       (require ns'))))
 
 (defn realize-symbol-or-self
-  "Given a symbol, gets what it names. Otherwise, returns the
-  argument.
+  "Given a symbol, gets what it names. Otherwise, returns the argument.
+
+  if `resolve?` is true, returns the value in the var;
+  otherwise, returns the var itself.
 
   ((realize-symbol-or-self 'clojure.core/inc) 4) ;;=> 5
   ((realize-symbol-or-self inc) 5)               ;;=> 6"
-  [x]
+  [x resolve?]
   (if (symbol? x)
     (try
       (require-ns x)
-      (-> x
-          find-var
-          var-get)
+      (cond-> (find-var x)
+        resolve? var-get)
       (catch Exception e
         (throw
          (ex-info (str "ERROR while trying realize symbol" (pr-str x))
                   {:symbol x, :cause e}))))
     x))
+
+(defn realize-fn [x] (realize-symbol-or-self x false))
+(defn realize-chan [x] (realize-symbol-or-self x true))
 
 (defn init-exchange!
   "Initializes an exchange.
@@ -125,7 +129,7 @@
 
   (let [in-chan (async/chan)
         out-chan (async/chan)
-        f (realize-symbol-or-self f)
+        f (realize-fn f)
         ignore-no-reply-to? (not response)
         streaming? (= response :streaming)
         rabbit-ch (wire-up/incoming-service connection
@@ -185,7 +189,7 @@
          timeout default-timeout
          response nil}}]
 
-  (let [channel (realize-symbol-or-self channel)
+  (let [channel (realize-chan channel)
         rabbit-ch (cond
                     (= response :streaming) (wire-up/streaming-external-service
                                              connection
@@ -243,7 +247,7 @@
          threads wire-up/default-thread-count
          timeout default-timeout}}]
 
-  (let [f (realize-symbol-or-self f)
+  (let [f (realize-fn f)
         channel (async/chan 100)
         rabbit-ch (wire-up/incoming-events-channel connection
                                                    queue
@@ -276,7 +280,7 @@
    {:keys [exchange routing-key channel]
     :or {exchange default-exchange}}]
 
-  (let [out-channel (realize-symbol-or-self channel)
+  (let [out-channel (realize-chan channel)
         rabbit-ch (wire-up/outgoing-events-channel
                    connection
                    exchange
@@ -308,7 +312,7 @@
   [connection {:keys [jobs-chan queue queue-options exchange]
                :or {queue-options default-queue-options
                     exchange default-exchange}}]
-  (let [jobs-chan (realize-symbol-or-self jobs-chan)
+  (let [jobs-chan (realize-chan jobs-chan)
         outgoing-ch (langohr.channel/open connection)]
     (lq/declare outgoing-ch queue queue-options)
     (kehaar.core/async=>rabbit jobs-chan outgoing-ch exchange queue)
@@ -388,7 +392,7 @@
                                  work-ch
                                  jobs/kehaar-exchange
                                  "kehaar-worker")))
-  (let [f (realize-symbol-or-self f)
+  (let [f (realize-fn f)
         in-chan (async/chan)
         ch (lchan/open connection)]
     (lq/declare ch queue queue-options)

--- a/src/kehaar/configured.clj
+++ b/src/kehaar/configured.clj
@@ -39,20 +39,21 @@
 
   ((realize-symbol-or-self 'clojure.core/inc) 4) ;;=> 5
   ((realize-symbol-or-self inc) 5)               ;;=> 6"
-  [x resolve?]
-  (if (symbol? x)
-    (try
-      (require-ns x)
-      (if-let [v (find-var x)]
-        (if resolve?
-          (var-get v)
-          v)
-        (throw (ex-info (str "#'" (pr-str x) " does not exist") {})))
-      (catch Exception e
-        (throw
-         (ex-info (str "ERROR while trying realize symbol " (pr-str x))
-                  {:symbol x, :cause e}))))
-    x))
+  ([x] (realize-symbol-or-self x true))
+  ([x resolve?]
+   (if (symbol? x)
+     (try
+       (require-ns x)
+       (if-let [v (find-var x)]
+         (if resolve?
+           (var-get v)
+           v)
+         (throw (ex-info (str "#'" (pr-str x) " does not exist") {})))
+       (catch Exception e
+         (throw
+          (ex-info (str "ERROR while trying realize symbol" (pr-str x))
+                   {:symbol x, :cause e}))))
+     x)))
 
 (defn realize-fn
   ([x] (realize-fn x debug-handlers?))

--- a/src/kehaar/configured.clj
+++ b/src/kehaar/configured.clj
@@ -4,6 +4,7 @@
             [kehaar.core]
             [kehaar.response-queues :as rq]
             [clojure.core.async :as async]
+            [clojure.string :as string]
             [clojure.tools.logging :as log]
             [langohr.core :as rmq]
             [langohr.basic :as lb]
@@ -22,6 +23,13 @@
   (let [ns' (symbol (namespace sym))]
     (when-not (find-ns ns')
       (require ns'))))
+
+(def debug-handlers?
+  (some-> (System/getenv "KEHAAR_DEBUG")
+          string/lower-case
+          string/trim
+          #{"1" "true"}
+          boolean))
 
 (defn realize-symbol-or-self
   "Given a symbol, gets what it names. Otherwise, returns the argument.
@@ -43,7 +51,7 @@
                   {:symbol x, :cause e}))))
     x))
 
-(defn realize-fn [x] (realize-symbol-or-self x false))
+(defn realize-fn [x] (realize-symbol-or-self x (not debug-handlers?)))
 (defn realize-chan [x] (realize-symbol-or-self x true))
 
 (defn init-exchange!

--- a/test/kehaar/configured_test.clj
+++ b/test/kehaar/configured_test.clj
@@ -12,3 +12,26 @@
     (testing "throws when symbol can't be resolved"
       (is (thrown? Exception (realize-symbol-or-self 'not.a.real.ns/bad)))
       (is (thrown? Exception (realize-symbol-or-self 'clojure.core/NOPE))))))
+
+(deftest realize-fn-test
+  (testing "with a var"
+    (is (= inc (realize-fn inc false))))
+  (testing "with a symbol"
+    (is (= inc (realize-fn 'clojure.core/inc false)))
+    (testing "can resolve something in a ns not yet required"
+      (is (= :bar (realize-fn 'kehaar.not-yet-required/foo false))))
+    (testing "throws when symbol can't be resolved"
+      (is (thrown? Exception (realize-fn 'not.a.real.ns/bad false)))
+      (is (thrown? Exception (realize-fn 'clojure.core/NOPE false))))))
+
+(deftest realize-fn-debug-test
+  (testing "with a var"
+    (is (= inc (realize-fn inc :debug))))
+  (testing "with a symbol"
+    ;; This returns a var -- a subtle difference from the non-debug version
+    (is (= #'inc (realize-fn 'clojure.core/inc :debug)))
+    (testing "can resolve something in a ns not yet required"
+      (is (= :bar (realize-fn 'kehaar.not-yet-required/foo :debug))))
+    (testing "throws when symbol can't be resolved"
+      (is (thrown? Exception (realize-fn 'not.a.real.ns/bad :debug)))
+      (is (thrown? Exception (realize-fn 'clojure.core/NOPE :debug))))))

--- a/test/kehaar/configured_test.clj
+++ b/test/kehaar/configured_test.clj
@@ -8,18 +8,19 @@
   (testing "with a symbol"
     (is (= inc (realize-symbol-or-self 'clojure.core/inc)))
     (testing "can resolve something in a ns not yet required"
-      (is (= :bar ((realize-symbol-or-self 'kehaar.not-yet-required/foo)))))
+      (is (= :bar (realize-symbol-or-self 'kehaar.not-yet-required/foo))))
     (testing "throws when symbol can't be resolved"
       (is (thrown? Exception (realize-symbol-or-self 'not.a.real.ns/bad)))
       (is (thrown? Exception (realize-symbol-or-self 'clojure.core/NOPE))))))
+
+;; Now that we've tested 'kehaar.not-yet-required/foo, that namespace has been
+;; required, so there's no sense in testing it again
 
 (deftest realize-fn-test
   (testing "with a var"
     (is (= inc (realize-fn inc false))))
   (testing "with a symbol"
     (is (= inc (realize-fn 'clojure.core/inc false)))
-    (testing "can resolve something in a ns not yet required"
-      (is (= :bar ((realize-fn 'kehaar.not-yet-required/foo false)))))
     (testing "throws when symbol can't be resolved"
       (is (thrown? Exception (realize-fn 'not.a.real.ns/bad false)))
       (is (thrown? Exception (realize-fn 'clojure.core/NOPE false))))))
@@ -30,8 +31,6 @@
   (testing "with a symbol"
     ;; This returns a var -- a subtle difference from the non-debug version
     (is (= #'inc (realize-fn 'clojure.core/inc :debug)))
-    (testing "can resolve something in a ns not yet required"
-      (is (= :bar ((realize-fn 'kehaar.not-yet-required/foo :debug)))))
     (testing "throws when symbol can't be resolved"
       (is (thrown? Exception (realize-fn 'not.a.real.ns/bad :debug)))
       (is (thrown? Exception (realize-fn 'clojure.core/NOPE :debug))))))

--- a/test/kehaar/configured_test.clj
+++ b/test/kehaar/configured_test.clj
@@ -8,7 +8,7 @@
   (testing "with a symbol"
     (is (= inc (realize-symbol-or-self 'clojure.core/inc)))
     (testing "can resolve something in a ns not yet required"
-      (is (= :bar (realize-symbol-or-self 'kehaar.not-yet-required/foo))))
+      (is (= :bar ((realize-symbol-or-self 'kehaar.not-yet-required/foo)))))
     (testing "throws when symbol can't be resolved"
       (is (thrown? Exception (realize-symbol-or-self 'not.a.real.ns/bad)))
       (is (thrown? Exception (realize-symbol-or-self 'clojure.core/NOPE))))))
@@ -19,7 +19,7 @@
   (testing "with a symbol"
     (is (= inc (realize-fn 'clojure.core/inc false)))
     (testing "can resolve something in a ns not yet required"
-      (is (= :bar (realize-fn 'kehaar.not-yet-required/foo false))))
+      (is (= :bar ((realize-fn 'kehaar.not-yet-required/foo false)))))
     (testing "throws when symbol can't be resolved"
       (is (thrown? Exception (realize-fn 'not.a.real.ns/bad false)))
       (is (thrown? Exception (realize-fn 'clojure.core/NOPE false))))))
@@ -31,7 +31,7 @@
     ;; This returns a var -- a subtle difference from the non-debug version
     (is (= #'inc (realize-fn 'clojure.core/inc :debug)))
     (testing "can resolve something in a ns not yet required"
-      (is (= :bar (realize-fn 'kehaar.not-yet-required/foo :debug))))
+      (is (= :bar ((realize-fn 'kehaar.not-yet-required/foo :debug)))))
     (testing "throws when symbol can't be resolved"
       (is (thrown? Exception (realize-fn 'not.a.real.ns/bad :debug)))
       (is (thrown? Exception (realize-fn 'clojure.core/NOPE :debug))))))

--- a/test/kehaar/not_yet_required.clj
+++ b/test/kehaar/not_yet_required.clj
@@ -1,3 +1,3 @@
 (ns kehaar.not-yet-required)
 
-(def foo :bar)
+(defn foo [] :bar)

--- a/test/kehaar/not_yet_required.clj
+++ b/test/kehaar/not_yet_required.clj
@@ -1,3 +1,3 @@
 (ns kehaar.not-yet-required)
 
-(defn foo [] :bar)
+(def foo :bar)


### PR DESCRIPTION
Currently when developing at a repl, you can't redefine kehaar handlers that are set up with `kehaar.configured`. This PR uses clojure vars for handler functions when possible, which allows using a reload repl workflow.

`realize-symbol-or-self` is wrapped twice: `realize-fn` for functions (which can be replaced by vars naming functions), and `realize-chan` for async channels (which need to be actual channels). 

This behavior can be turned on by setting an env var: `KEHAAR_DEBUG`, though I'm open to feedback on other ways to control this behavior.