### PR TITLE
Fix race conditions in streaming

### DIFF
--- a/src/kehaar/core.clj
+++ b/src/kehaar/core.clj
@@ -29,13 +29,10 @@
            ;; don't requeue nil, it's invalid
            [:nack delivery-tag false]
 
-           (= ::stop message)
+           (and (= ::stop message) close-channel?)
            ;; ack it and close the channel if close-channel?
            (do
-             (if close-channel?
-               (async/close! channel)
-               (bounded>!! channel {:message message
-                                    :metadata metadata} timeout))
+             (async/close! channel)
              [:ack delivery-tag])
 
            :else

--- a/src/kehaar/wire_up.clj
+++ b/src/kehaar/wire_up.clj
@@ -266,15 +266,13 @@
                   (let [msg (async/<! message-channel)]
                     (when (get-in @pending-calls [correlation-id :timeout])
                       (swap! pending-calls update correlation-id dissoc :timeout))
-                    (if (nil? msg)
-                      (async/close! return-channel)
-                      (if (async/>! return-channel msg)
-                        (recur)
-                        (do
-                          (when-not (langohr.core/closed? response-ch)
-                            (langohr.core/close response-ch))
-                          (swap! pending-calls dissoc correlation-id)
-                          (async/close! message-channel)))))))
+                    (if (and (some? msg) (async/>! return-channel msg))
+                      (recur)
+                      (do
+                        (async/close! return-channel)
+                        (langohr.core/close response-ch)
+                        (swap! pending-calls dissoc correlation-id)
+                        (async/close! message-channel))))))
               (do
                 (log/info (format "Deleting queue %s" (:kehaar.core/response-queue message)))
                 (langohr.queue/delete ch (:kehaar.core/response-queue message))))

--- a/src/kehaar/wire_up.clj
+++ b/src/kehaar/wire_up.clj
@@ -237,7 +237,8 @@
        (rq/set-response-queue! queue-name response-queue)
 
        ;; start listening for responses
-       (kehaar.core/rabbit=>async ch response-queue <response-channel
+       (kehaar.core/rabbit=>async shared-response-ch
+                                  response-queue <response-channel
                                   {:exclusive true} 1000)
        (kehaar.core/go-handler
         [{:keys [message metadata]} <response-channel]

--- a/test/kehaar/streaming_test.clj
+++ b/test/kehaar/streaming_test.clj
@@ -1,0 +1,61 @@
+(ns kehaar.streaming-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [kehaar.core :as k.core]
+            [kehaar.configured :as configured]
+            [kehaar.wire-up :as wire-up]
+            [clojure.core.async :as async]
+            [langohr.core :as rmq]
+            [kehaar.test-config :refer [rmq-config]]))
+
+(deftest ^:rabbit-mq streaming-test
+  (let [conn (rmq/connect rmq-config)
+        stream-ch (async/chan 1)
+        call! (wire-up/async->fn stream-ch)
+        state (configured/init! conn
+                                {:incoming-services
+                                 [{:queue "stream-test"
+                                   :f #(range (:n %))
+                                   :response :streaming
+                                   :threads 1
+                                   :threshold 10}]
+                                 :external-services
+                                 [{:queue "stream-test"
+                                   :channel stream-ch
+                                   :response :streaming
+                                   :timeout 30000}]})]
+    (try
+      (testing "when streaming size is below the threshold"
+        (is (= (range 8) (k.core/async->lazy-seq (call! {:n 8})))))
+      (testing "when streaming size is at the threshold"
+        (is (= (range 10) (k.core/async->lazy-seq (call! {:n 10})))))
+      (testing "when streaming size is above the threshold"
+        (is (= (range 100) (k.core/async->lazy-seq (call! {:n 100})))))
+      (testing "with a consumer that is slow to start and a short response"
+        (let [response (k.core/async->lazy-seq (call! {:n 5}))]
+          (println "# sleeping 2 seconds...")
+          (Thread/sleep 2000)
+          (is (= (range 5) response))))
+      (testing "with a consumer that is slow to start and a long response"
+        (let [response (k.core/async->lazy-seq (call! {:n 20}))]
+          (println "# sleeping 2 seconds...")
+          (Thread/sleep 2000)
+          (is (= (range 20) response))))
+      (testing "with a slow consumer and a short response"
+        (print "# slow consumer test (5 items)...") (flush)
+        (let [response (->> (call! {:n 5})
+                            k.core/async->lazy-seq
+                            (map (fn [x] (print x) (flush) (Thread/sleep 1000) (print ".") (flush) x))
+                            doall)]
+          (println)
+          (is (= (range 5) response))))
+      (testing "with a slow consumer and a long response"
+        (print "# slow consumer test (20 items)...")
+        (let [response (->> (call! {:n 20})
+                            k.core/async->lazy-seq
+                            (map (fn [x] (print x) (flush) (Thread/sleep 1000) (print ".") (flush) x))
+                            doall)]
+          (println)
+          (is (= (range 20) response))))
+      (finally
+        (configured/shutdown! state)
+        (rmq/close conn)))))


### PR DESCRIPTION
Kehaar streaming has a couple of race conditions. The first commit of this PR is a set of failing tests -- the straightforward tests passed already, but the tests that introduce artificial timing issues failed.

The main problem is that while we were correctly setting a prefetch of 1 on a channel, we used a different channel to get responses from the queue, causing messages to come out of order. This PR also fixes a couple of edge cases where streaming channels and queues were not cleaned up.