### PR TITLE
Better publisher state management

### DIFF
--- a/src/kehaar/configured.clj
+++ b/src/kehaar/configured.clj
@@ -488,3 +488,107 @@
       (swap! states conj (init-outgoing-job! connection outgoing-job)))
 
     @states))
+
+;; -- Alternate API -----------------------------------------------------------
+
+;; This API usese the above functions, but considers kehaar state to be divided
+;; into two categories, which are handled differently:
+;;   Consumers -- single state, as a map of routes (c.f. pedestal route table)
+;;   Publishers -- multiple states, one per publisher
+
+(defn init-consumers!
+  "Like init! but only initializes exchanges and incoming-* keys."
+  [connection configuration]
+  (init! connection
+         (select-keys configuration [:exchanges
+                                     :incoming-services
+                                     :incoming-events
+                                     :incoming-jobs])))
+
+(defrecord Publisher [state f channel]
+  clojure.lang.IFn
+  (invoke [_ message]
+    (f message)))
+
+(defrecord JobPublisher [state f channel]
+  clojure.lang.IFn
+  (invoke [_ message callback]
+    (f message callback)))
+
+(defn- init-publisher* [publisher-type connection configuration]
+  (case publisher-type
+    :service (init-external-service! connection configuration)
+    :event (init-outgoing-event! connection configuration)
+    :job (init-outgoing-job! connection configuration)))
+
+(defn- wire-up-publisher [publisher-type configuration]
+  (case publisher-type
+    :service (if (:response configuration)
+               (wire-up/async->fn (:channel configuration))
+               (wire-up/async->fire-and-forget-fn (:channel configuration)))
+    :event (fn [message] (async/>!! (:channel configuration) message))
+    :job (jobs/async->job (:jobs-chan configuration))))
+
+(defn publisher-config->type
+  "Determines the publisher type based on the following rules:
+
+  * outgoing-jobs must have {:response :job}
+  * external-services must have a :response (true, false, or :streaming)
+  * outgoing-events must have both :exchange and :routing-key"
+  [configuration]
+  (cond
+    (contains? #{true false :streaming} (:response configuration)) :service
+    (= :job (:response configuration)) :job
+    (and (:exchange configuration) (:routing-key configuration)) :event
+    :else (throw (ex-info "Unable to determine publisher-type from configuration"
+                          configuration))))
+
+(defn find-publisher-config
+  [configuration queue-or-routing-key]
+  (->> (concat (:publishers configuration)
+               ;; for compatibility, also check external-services,
+               ;; outgoing-events, and outgoing-jobs
+               (:external-services configuration)
+               (:outgoing-events configuration)
+               (map #(assoc % :response :job) (:outgoing-jobs configuration)))
+       (filter #(= queue-or-routing-key (some % [:queue :routing-key])))
+       first))
+
+(defn init-publisher!
+  "Initializes and wires-up up a publisher using a configuration map.
+
+  Returns a `Publisher` or `JobPublisher` that encapsulates kehaar state, an
+  async channel, and a wire-up function. The returned record can be called as a
+  function:
+
+  ;; Create a publisher
+  (def cfg {:queue \"test-queue\" :response true :timeout 10000})
+  (def my-publisher (wire-up-publisher! conn cfg))
+
+  ;; Publish a message, and get a response
+  (def response (async/<!! (my-publisher {:hello :world})))
+
+  ;; Clean up
+  (stop-publisher! my-publisher)"
+  ([connection full-config queue-or-routing-key]
+   (if-let [config (find-publisher-config full-config queue-or-routing-key)]
+     (init-publisher! connection config)
+     (throw (ex-info (str "Unable to find queue or routing key: '"
+                          queue-or-routing-key
+                          "'in config") {}))))
+  ([connection configuration]
+   (let [publisher-type (publisher-config->type configuration)
+         job? (= :job publisher-type)
+         ch (async/chan)
+         configuration (assoc configuration (if job? :jobs-chan :channel) ch)
+         state (init-publisher* publisher-type connection configuration)
+         f (wire-up-publisher publisher-type configuration)]
+     (if job?
+       (->JobPublisher state f ch)
+       (->Publisher state f ch)))))
+
+(defn shutdown-publisher!
+  "Shuts down kehaar state and the async channel created by wire-up-publisher!"
+  [{:keys [state channel]}]
+  (shutdown-part! state)
+  (async/close! channel))


### PR DESCRIPTION
Mostly I'm looking to start a discussion about how we can integrate state-management libraries with kehaar in a more seamless way. This might not be the best solution, but I think it's a good starting place to bounce ideas off of.

---

It's easy enough to contain all of the consumer states in a single place (configured already does that), but between def-ing publisher (=outgoing) channels and wiring-up functions for those channels, we're already treating publishers as individual pieces of state.

This PR makes it possible to initialize a publisher in one step by making kehaar handle the async channel lifecycle. Publishers returned from `init-publisher!` are records that hold all the state they need, and implement `clojure.lang.IFn` (maybe too cute) by calling the appropriate wired-up function for the publisher type (event, job, service, or fire-and-forget service).

An example of how you might use this:

```clj
(def conn (langohr.core/connect {:host "localhost" :port 5672}))
(def config {;; consumers -- no config changes
             :incoming-services
             [{:queue "foo.read"
               :response true
               :f foo.handlers/read}]
             :incoming-events
             [{:queue "foo.event.bar-create"
               :routing-key "bar.create"
               :exchange "events"
               :f foo.handlers/on-bar-create}]
             :incoming-jobs
             [{:queue "foo.export"
               :f foo.handlers/export-job}]
             ;; publishers -- these do not have :channels
             :external-services
             [{:queue "bar.read" :response true :timeout 10000}]
             :outgoing-events
             [{:routing-key "events.foo.created" :exchange "events"}]
             :outgoing-jobs
             [{:queue "bar.long-job"}]})

;; Init only the incoming-* events
(def consumer-state (kehaar.configured/init-consumers! conn config))

;; Init individual publishers
(def read-bar (kehaar.configured/init-publisher! conn config "bar.read"))
(def create-foo-event (kehaar.configured/init-publisher! conn config "events.foo.created"))
(def bar-job (kehaar.configured/init-publisher! conn config "bar.long-job"))

;; Call publishers as if they were wired-up functions
(def some-bar (async/<!! (read-bar {:bar/id 123})))
(create-foo-event {:foo/id "xyz"})
(bar-job {:bar/job-type :frob}
         (fn [result]
           (println "bar/frob done with result" result)))

;; Stop everything
(kehaar.configured/shutdown! consumer-state)
(run! kehaar.configured/shutdown-publisher! [some-bar create-foo-event bar-job])

;; Or, managing state with mount:
(defstate conn
  :start (langohr.core/connect {:host "localhost" :port 5672})
  :stop (langohr.core/close conn))

(defstate consumers
  :start (kehaar.configured/init-consumers! conn config)
  :stop (kehaar.configured/shutdown! consumers))

(defstate read-bar
  :start (kehaar.configured/init-publisher! conn config "bar.read")
  :stop (kehaar.configured/shutdown-publisher! read-bar))
```

Notes:

`find-publisher-config` is used as a compatibility layer between existing kehaar config maps that include external-services/outgoing-events/outgoing-jobs. If we like this idea, it might be more practical to give each publisher a place in the top-level kehaar map and then reference those configs directly:
```clj
(def config
  {:read-bar {:queue "bar.read" :response true :timeout 10000}
   :create-foo-event {:routing-key "events.foo.created" :exchange "events"}
   :bar-job {:queue "bar.long-job" :response :job}})

(def read-bar (kehaar.configured/init-publisher! conn (:read-bar config)))
(def create-foo-event (kehaar.configured/init-publisher! conn (:create-foo-event config)))
(def bar-job (kehaar.configured/init-publisher! conn (:bar-job config)))
```