### PR TITLE
Do not recover streaming response channels

### DIFF
--- a/src/kehaar/core.clj
+++ b/src/kehaar/core.clj
@@ -1,6 +1,7 @@
 (ns kehaar.core
   (:require [clojure.core.async :as async]
             [langohr.basic :as lb]
+            [langohr.channel]
             [langohr.consumers :as lc]
             [langohr.queue :as lq]
             [clojure.tools.logging :as log]
@@ -224,7 +225,9 @@
           (= sent-count threshold)      ; set up bespoke queue and start using it
           (let [ch (langohr.channel/open connection)
                 response-queue (langohr.queue/declare-server-named
-                                ch
+                                ;; we don't want to auto-recover this queue
+                                ;; since it is really "owned" by the consumer
+                                (langohr.channel/as-non-recovering-channel ch)
                                 {:exclusive false
                                  :auto-delete true
                                  :durable false})


### PR DESCRIPTION
The RabbitMQ Java client does channel and topology recovery when it
detects connection issues. This includes declaring any queue that was
declared by this connection, but that was not deleted by the connection.
Since bespoke streaming response queues are created by the responder,
but deleted by the consumer, the responder has no way of knowing that
the queue was deleted. This means that when the responder handles
automatic recovery, it re-declares every bespoke response queue it has
ever created.

The idea behind the test is straightforward, but the implementation is a little tricky. I went through a couple iterations to make it as deterministic as possible -- for comparison, see an [earlier attempt](https://github.com/democracyworks/kehaar/commit/a6c83e8fe5a10a94f74589799db69a49ec2d0842).

1. send off some large streaming requests
2. trigger a connection failure to force recovery (by making a heartbeat fail -- this is fiddly)
3. check to make sure none of the `amq.gen` queues were recovered

Without the change in this PR, the above test fails, since the bespoke response queues are recovered.